### PR TITLE
Sw panda

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ logs/*
 public/build
 
 npm-debug.log
+
+conf/local.conf

--- a/app/controllers/App.scala
+++ b/app/controllers/App.scala
@@ -1,14 +1,19 @@
 package controllers
 
+import play.api.Configuration
+import play.api.libs.ws.WSClient
 import play.api.mvc._
 
-class App extends Controller {
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
-  def hello = Action {
+class App(override val wsClient: WSClient) extends Controller with PandaAuthActions {
+
+  def hello = AuthAction {
     Ok("hello world")
   }
 
-  def index = Action {
+  def index = AuthAction {
 
     val jsFileName = "build/app.js"
 
@@ -18,6 +23,18 @@ class App extends Controller {
     }
 
     Ok(views.html.Application.app("Campaign Central", jsLocation))
+  }
+
+  def reauth = AuthAction {
+    Ok("auth ok")
+  }
+
+  def oauthCallback = Action.async { implicit request =>
+    processGoogleCallback()
+  }
+
+  def logout = Action.async { implicit request =>
+    Future(processLogout)
   }
 }
 

--- a/app/controllers/CampaignApi.scala
+++ b/app/controllers/CampaignApi.scala
@@ -2,10 +2,12 @@ package controllers
 
 import model._
 import org.joda.time.DateTime
+import play.api.Configuration
 import play.api.libs.json._
+import play.api.libs.ws.WSClient
 import play.api.mvc.{Action, Controller}
 
-class CampaignApi extends Controller {
+class CampaignApi(override val wsClient: WSClient) extends Controller with PandaAuthActions {
 
   private val tempUser = User("Temp", "User", "temp@user.fake")
 
@@ -16,11 +18,11 @@ class CampaignApi extends Controller {
   )
 
 
-  def getAllCampaigns() = Action { req =>
+  def getAllCampaigns() = APIAuthAction { req =>
     Ok(Json.toJson(tempCampaignList))
   }
 
-  def getCampaign(id: String) = Action { req =>
+  def getCampaign(id: String) = APIAuthAction { req =>
     tempCampaignList.find(_.id == id) match {
       case Some(c) => Ok(Json.toJson(c))
       case None => NotFound

--- a/app/controllers/PandaAuthActions.scala
+++ b/app/controllers/PandaAuthActions.scala
@@ -1,0 +1,27 @@
+package controllers
+
+import com.amazonaws.auth.{AWSCredentialsProvider}
+import com.gu.pandomainauth.PanDomain
+import com.gu.pandomainauth.action.AuthActions
+import com.gu.pandomainauth.model.AuthenticatedUser
+import play.api.Logger
+import services.{AWS, Config}
+
+trait PandaAuthActions extends AuthActions {
+
+  override lazy val domain: String = Config().pandaDomain
+
+  override def authCallbackUrl: String = Config().pandaAuthCallback
+
+  override lazy val system: String = "campaignCentral"
+
+  override def cacheValidation = true
+
+  override lazy val awsCredentialsProvider: AWSCredentialsProvider = AWS.credentialsProvider
+
+  override def validateUser(authedUser: AuthenticatedUser): Boolean = {
+    Logger.info(s"validating user $authedUser")
+    PanDomain.guardianValidation(authedUser)
+  }
+
+}

--- a/app/di.scala
+++ b/app/di.scala
@@ -1,0 +1,30 @@
+import controllers.{App, Assets, CampaignApi}
+import play.api.{Application, ApplicationLoader, BuiltInComponentsFromContext}
+import play.api.ApplicationLoader.Context
+import play.api.libs.ws.ahc.AhcWSComponents
+import play.api.routing.Router
+import services.AWS
+import router.Routes
+
+
+class AppLoader extends ApplicationLoader {
+  def load(context: Context): Application = {
+    new AppComponents(context).application
+  }
+}
+
+class AppComponents(context: Context) extends BuiltInComponentsFromContext(context) with AhcWSComponents {
+
+  AWS.init(configuration.getString("aws.profile"))
+
+  val appController = new App(wsClient)
+  val campaignApiController = new CampaignApi(wsClient)
+  val assetsController = new Assets(httpErrorHandler)
+
+  def router: Router = new Routes(
+    httpErrorHandler,
+    appController,
+    campaignApiController,
+    assetsController
+  )
+}

--- a/app/di.scala
+++ b/app/di.scala
@@ -1,4 +1,4 @@
-import controllers.{App, Assets, CampaignApi}
+import controllers._
 import play.api.{Application, ApplicationLoader, BuiltInComponentsFromContext}
 import play.api.ApplicationLoader.Context
 import play.api.libs.ws.ahc.AhcWSComponents
@@ -19,12 +19,14 @@ class AppComponents(context: Context) extends BuiltInComponentsFromContext(conte
 
   val appController = new App(wsClient)
   val campaignApiController = new CampaignApi(wsClient)
+  val managementController = new Management()
   val assetsController = new Assets(httpErrorHandler)
 
   def router: Router = new Routes(
     httpErrorHandler,
     appController,
     campaignApiController,
-    assetsController
+    assetsController,
+    managementController
   )
 }

--- a/app/services/AWS.scala
+++ b/app/services/AWS.scala
@@ -1,0 +1,47 @@
+package services
+
+import com.amazonaws.auth.{AWSCredentialsProvider, DefaultAWSCredentialsProviderChain}
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
+import com.amazonaws.regions.{Region, Regions}
+import com.amazonaws.services.ec2.AmazonEC2Client
+import com.amazonaws.services.ec2.model.{DescribeTagsRequest, Filter}
+import com.amazonaws.util.EC2MetadataUtils
+import scala.collection.JavaConverters._
+
+
+object AWS {
+
+  lazy val region = Region getRegion Regions.EU_WEST_1
+
+  var creds: AWSCredentialsProvider = null
+
+  def init(profile: Option[String]): Unit = {
+    creds = profile map {p =>
+      new ProfileCredentialsProvider(p)
+    } getOrElse(
+      new DefaultAWSCredentialsProviderChain()
+      )
+  }
+
+  def credentialsProvider = creds
+
+  lazy val EC2Client = region.createClient(classOf[AmazonEC2Client], creds, null)
+
+}
+
+trait AwsInstanceTags {
+  lazy val instanceId = Option(EC2MetadataUtils.getInstanceId)
+
+  def readTag(tagName: String) = {
+    instanceId.flatMap { id =>
+      val tagsResult = AWS.EC2Client.describeTags(
+        new DescribeTagsRequest().withFilters(
+          new Filter("resource-type").withValues("instance"),
+          new Filter("resource-id").withValues(id),
+          new Filter("key").withValues(tagName)
+        )
+      )
+      tagsResult.getTags.asScala.find(_.getKey == tagName).map(_.getValue)
+    }
+  }
+}

--- a/app/services/Config.scala
+++ b/app/services/Config.scala
@@ -1,0 +1,34 @@
+package services
+
+object Config extends AwsInstanceTags {
+
+  lazy val conf = readTag("Stage") match {
+    case Some("PROD") =>    new ProdConfig
+    case Some("CODE") =>    new CodeConfig
+    case _ =>               new DevConfig
+  }
+
+  def apply() = {
+    conf
+  }
+}
+
+sealed trait Config {
+  def pandaDomain: String
+  def pandaAuthCallback: String
+}
+
+class DevConfig extends Config {
+  override def pandaDomain: String = "local.dev-gutools.co.uk"
+  override def pandaAuthCallback: String = "https://campaign-central.local.dev-gutools.co.uk/oauthCallback"
+}
+
+class CodeConfig extends Config {
+  override def pandaDomain: String = "code.dev-gutools.co.uk"
+  override def pandaAuthCallback: String = "https://campaign-central.code.dev-gutools.co.uk/oauthCallback"
+}
+
+class ProdConfig extends Config {
+  override def pandaDomain: String = "gutools.co.uk"
+  override def pandaAuthCallback: String = "https://campaign-central.gutools.co.uk/oauthCallback"
+}

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,9 @@ version := "1.0"
 
 lazy val dependencies = Seq(
   "com.amazonaws" % "aws-java-sdk" % "1.10.33",
-  "ai.x" %% "play-json-extensions" % "0.8.0"
+  "ai.x" %% "play-json-extensions" % "0.8.0",
+  "com.gu" % "pan-domain-auth-play_2-5_2.11" % "0.4.0",
+  ws
 )
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala, SbtWeb)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -44,3 +44,7 @@ application.langs="en"
 # ~~~~~
 # You can disable evolutions if needed
 # evolutionplugin=disabled
+
+play.application.loader = AppLoader
+
+include "local.conf"

--- a/conf/example-local.conf
+++ b/conf/example-local.conf
@@ -1,0 +1,4 @@
+
+aws {
+  profile = "composer"
+}

--- a/conf/routes
+++ b/conf/routes
@@ -1,6 +1,10 @@
 GET	/		            controllers.App.index
 GET	/hello		        controllers.App.hello
 
+GET            /oauthCallback                                          controllers.App.oauthCallback
+GET            /logout                                                 controllers.App.logout
+GET            /reauth                                                 controllers.App.reauth
+
 #Campaign Api
 GET /api/campaigns          controllers.CampaignApi.getAllCampaigns
 GET /api/campaigns/:id      controllers.CampaignApi.getCampaign(id: String)


### PR DESCRIPTION
Adds panda auth to app.

Uses play's DI stuff to bootstrap the app, but going with a light touch here. The DI entry point initialises connection to AWS and other service objects use the bootstrapped connection. This should mean that most development patterns will be more like our other play apps (tag manager et al) as opposed to more like the spring nonsense of R2 (DI doesn't stand for despondency infection for nothing). Happy to revisit this is it becomes weird and unwieldy in the future.
