### PR TITLE
Sw campaign targets

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "file-loader": "^0.8.5",
     "node-sass": "^3.3.3",
     "panda-session": "^0.1.6",
+    "ramda": "^0.22.1",
     "react": "^15.3.0",
     "react-addons-css-transition-group": "^15.3.0",
     "react-dom": "^15.3.0",

--- a/public/components/Campaign/Campaign.js
+++ b/public/components/Campaign/Campaign.js
@@ -1,6 +1,5 @@
 import React, { PropTypes } from 'react';
-import CampaignInformationEdit from '../CampaignInformationEdit/CampaignInformationEdit';
-import CampaignTargetsEdit from '../CampaignInformationEdit/CampaignTargetsEdit';
+import CampaignEdit from '../CampaignInformationEdit/CampaignEdit';
 import CampaignAnalytics from '../CampaignAnalytics/CampaignAnalytics';
 
 class Campaign extends React.Component {
@@ -18,12 +17,7 @@ class Campaign extends React.Component {
       <div className="campaign">
         <h2>{this.props.campaign.name}</h2>
         <div className="campaign__row">
-          <div className="campaign__column">
-            <CampaignInformationEdit campaign={this.props.campaign} updateCampaign={this.props.campaignActions.updateCampaign} saveCampaign={this.props.campaignActions.saveCampaign}/>
-          </div>
-          <div className="campaign__column">
-            <CampaignTargetsEdit campaign={this.props.campaign} updateCampaign={this.props.campaignActions.updateCampaign} saveCampaign={this.props.campaignActions.saveCampaign}/>
-          </div>
+          <CampaignEdit campaign={this.props.campaign} updateCampaign={this.props.campaignActions.updateCampaign} saveCampaign={this.props.campaignActions.saveCampaign}/>
         </div>
         <div className="campaign__row">
             <CampaignAnalytics campaign={this.props.campaign} />

--- a/public/components/Campaign/Campaign.js
+++ b/public/components/Campaign/Campaign.js
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import CampaignInformationEdit from '../CampaignInformationEdit/CampaignInformationEdit';
+import CampaignTargetsEdit from '../CampaignInformationEdit/CampaignTargetsEdit';
 import CampaignAnalytics from '../CampaignAnalytics/CampaignAnalytics';
 
 class Campaign extends React.Component {
@@ -19,6 +20,9 @@ class Campaign extends React.Component {
         <div className="campaign__row">
           <div className="campaign__column">
             <CampaignInformationEdit campaign={this.props.campaign} updateCampaign={this.props.campaignActions.updateCampaign} saveCampaign={this.props.campaignActions.saveCampaign}/>
+          </div>
+          <div className="campaign__column">
+            <CampaignTargetsEdit campaign={this.props.campaign} updateCampaign={this.props.campaignActions.updateCampaign} saveCampaign={this.props.campaignActions.saveCampaign}/>
           </div>
         </div>
         <div className="campaign__row">

--- a/public/components/CampaignInformationEdit/AddTargetControl.js
+++ b/public/components/CampaignInformationEdit/AddTargetControl.js
@@ -71,6 +71,7 @@ class AddTargetControl extends React.Component {
           <select value={this.state.selectedTarget} onChange={this.updateSelectedMetric}>
             <option value=""></option>
             { availbleTargets.map((t) => <option key={t.value} value={t.value}>{t.name}</option>) }
+            <option value="custom">Custom</option>
           </select>
           <br/>
           Target: <EditableText value={this.state.target} onChange={this.updateTarget} />
@@ -85,6 +86,7 @@ class AddTargetControl extends React.Component {
         <select value={this.state.selectedTarget} onChange={this.updateSelectedMetric}>
           <option value=""></option>
           { availbleTargets.map((t) => <option key={t.value} value={t.value}>{t.name}</option>) }
+          <option value="custom">Custom</option>
         </select>
         &nbsp;Count: <EditableNumber value={this.state.value} onNumberChange={this.updateTargetValue} />
         {this.renderAddButton()}

--- a/public/components/CampaignInformationEdit/AddTargetControl.js
+++ b/public/components/CampaignInformationEdit/AddTargetControl.js
@@ -1,0 +1,96 @@
+import React, { PropTypes } from 'react';
+import R from 'ramda';
+import EditableNumber from '../utils/EditableNumber';
+import EditableText from '../utils/EditableText';
+
+import { defaultTargets } from '../../constants/defaultTargets'
+
+class AddTargetControl extends React.Component {
+
+  static propTypes = {
+    existingTargets: PropTypes.arrayOf(PropTypes.string).isRequired,
+    onTargetAdded: PropTypes.func.isRequired
+  };
+
+  static defaultProps = {
+    target: undefined,
+    value: null
+  }
+
+  state = {
+    isTargetValid: false
+  }
+
+  triggerAdd = () => {
+    this.props.onTargetAdded(this.state.target, this.state.value);
+    this.setState({
+      isTargetValid: false,
+      selectedTarget: undefined,
+      target: undefined,
+      value: null
+    });
+  }
+
+  updateSelectedMetric = (e) => {
+    const selected = e.target.value;
+
+    if (selected === 'custom') {
+      this.setState({selectedTarget: selected, target: undefined});
+    } else {
+      this.setState({selectedTarget: selected, target: selected});
+    }
+  }
+
+  updateTarget = (e) => {
+    this.setState({target: e.target.value});
+  }
+
+  updateTargetValue = (v) => {
+    this.setState({value: v});
+  }
+
+  renderAddButton = () => {
+    if (!this.state.target || !this.state.value) {
+      return;
+    }
+
+    return (
+      <div className="editable-text__button" onClick={this.triggerAdd} >
+      <i className="i-plus"/>
+    </div>
+    );
+  }
+  
+  render () {
+
+    const availbleTargets = defaultTargets.filter(t => !this.props.existingTargets.includes(t.value) );
+
+    if (this.state.selectedTarget === 'custom') {
+      return (
+        <div>
+          <select value={this.state.selectedTarget} onChange={this.updateSelectedMetric}>
+            <option value=""></option>
+            { availbleTargets.map((t) => <option key={t.value} value={t.value}>{t.name}</option>) }
+          </select>
+          <br/>
+          Target: <EditableText value={this.state.target} onChange={this.updateTarget} />
+          Count: <EditableNumber value={this.state.value} onNumberChange={this.updateTargetValue} />
+          {this.renderAddButton()}
+        </div>
+      )
+    }
+
+    return (
+      <div>
+        <select value={this.state.selectedTarget} onChange={this.updateSelectedMetric}>
+          <option value=""></option>
+          { availbleTargets.map((t) => <option key={t.value} value={t.value}>{t.name}</option>) }
+        </select>
+        &nbsp;Count: <EditableNumber value={this.state.value} onNumberChange={this.updateTargetValue} />
+        {this.renderAddButton()}
+      </div>
+    );
+  }
+}
+
+export default AddTargetControl;

--- a/public/components/CampaignInformationEdit/AddTargetControl.js
+++ b/public/components/CampaignInformationEdit/AddTargetControl.js
@@ -15,16 +15,13 @@ class AddTargetControl extends React.Component {
   static defaultProps = {
     target: undefined,
     value: null
-  }
+  };
 
-  state = {
-    isTargetValid: false
-  }
+  state = {};
 
   triggerAdd = () => {
     this.props.onTargetAdded(this.state.target, this.state.value);
     this.setState({
-      isTargetValid: false,
       selectedTarget: undefined,
       target: undefined,
       value: null

--- a/public/components/CampaignInformationEdit/CampaignEdit.js
+++ b/public/components/CampaignInformationEdit/CampaignEdit.js
@@ -15,7 +15,8 @@ class CampaignEdit extends React.Component {
     });
   }
 
-  markDirty = () => {
+  triggerUpdate = (newCampaign) => {
+    this.props.updateCampaign(newCampaign.id, newCampaign);
     this.setState({
       isCampaignDirty: true
     });
@@ -41,10 +42,10 @@ class CampaignEdit extends React.Component {
         </div>
         <div className="campaign-box__body">
           <div className="campaign__column">
-            <CampaignInformationEdit campaign={this.props.campaign} updateCampaign={this.props.updateCampaign} markDirty={this.markDirty}/>
+            <CampaignInformationEdit campaign={this.props.campaign} updateCampaign={this.triggerUpdate} />
           </div>
           <div className="campaign__column">
-            <CampaignTargetsEdit campaign={this.props.campaign} updateCampaign={this.props.updateCampaign} markDirty={this.markDirty}/>
+            <CampaignTargetsEdit campaign={this.props.campaign} updateCampaign={this.triggerUpdate} />
           </div>
         </div>
         {this.renderSaveButtons()}

--- a/public/components/CampaignInformationEdit/CampaignEdit.js
+++ b/public/components/CampaignInformationEdit/CampaignEdit.js
@@ -1,0 +1,56 @@
+import React, { PropTypes } from 'react';
+import CampaignInformationEdit from './CampaignInformationEdit';
+import CampaignTargetsEdit from './CampaignTargetsEdit';
+
+class CampaignEdit extends React.Component {
+
+  state = {
+    isCampaignDirty: false
+  }
+
+  triggerSave = () => {
+    this.props.saveCampaign(this.props.campaign.id, this.props.campaign);
+    this.setState({
+      isCampaignDirty: false
+    });
+  }
+
+  markDirty = () => {
+    this.setState({
+      isCampaignDirty: true
+    });
+  }
+
+  renderSaveButtons = () => {
+    if (!this.state.isCampaignDirty) {
+      return false;
+    }
+
+    return (
+      <div className="campaign-box__footer">
+        <span className="campaign-info__button" onClick={this.triggerSave}>Save</span>
+      </div>
+    );
+  }
+
+  render () {
+    return (
+      <div className="campaign-info campaign-box">
+        <div className="campaign-box__header">
+          Campaign Info
+        </div>
+        <div className="campaign-box__body">
+          <div className="campaign__column">
+            <CampaignInformationEdit campaign={this.props.campaign} updateCampaign={this.props.updateCampaign} markDirty={this.markDirty}/>
+          </div>
+          <div className="campaign__column">
+            <CampaignTargetsEdit campaign={this.props.campaign} updateCampaign={this.props.updateCampaign} markDirty={this.markDirty}/>
+          </div>
+        </div>
+        {this.renderSaveButtons()}
+      </div>
+    );
+  }
+}
+
+export default CampaignEdit;

--- a/public/components/CampaignInformationEdit/CampaignInformationEdit.js
+++ b/public/components/CampaignInformationEdit/CampaignInformationEdit.js
@@ -8,24 +8,17 @@ import {formatMillisecondDate} from '../../util/dateFormatter';
 class CampaignInformationEdit extends React.Component {
 
   static propTypes = {
-    updateCampaign: PropTypes.func.isRequired,
-    markDirty: PropTypes.func.isRequired
+    updateCampaign: PropTypes.func.isRequired
   };
 
-
-  triggerUpdate = (newCampaign) => {
-    this.props.markDirty();
-    this.props.updateCampaign(newCampaign.id, newCampaign);
-  }
-
   updateCampaignName = (e) => {
-    this.triggerUpdate(Object.assign({}, this.props.campaign, {
+    this.props.updateCampaign(Object.assign({}, this.props.campaign, {
       name: e.target.value
     }));
   }
 
   updateCampaignStatus = (e) => {
-    this.triggerUpdate(Object.assign({}, this.props.campaign, {
+    this.props.updateCampaign(Object.assign({}, this.props.campaign, {
       status: e.target.value
     }));
   }
@@ -36,7 +29,7 @@ class CampaignInformationEdit extends React.Component {
 
     const numValue = parseInt(value) === NaN ? undefined : parseInt(value);
 
-    this.triggerUpdate(Object.assign({}, this.props.campaign, {
+    this.props.updateCampaign(Object.assign({}, this.props.campaign, {
       actualValue: numValue
     }));
   }

--- a/public/components/CampaignInformationEdit/CampaignInformationEdit.js
+++ b/public/components/CampaignInformationEdit/CampaignInformationEdit.js
@@ -5,22 +5,14 @@ import {formatMillisecondDate} from '../../util/dateFormatter';
 
 class CampaignInformationEdit extends React.Component {
 
-  state = {
-    isCampaignDirty: false
-  }
+  static propTypes = {
+    updateCampaign: PropTypes.func.isRequired,
+    markDirty: PropTypes.func.isRequired
+  };
 
-  triggerSave = () => {
-    this.props.saveCampaign(this.props.campaign.id, this.props.campaign);
-    this.setState({
-      isCampaignDirty: false
-    });
-  }
 
   triggerUpdate = (newCampaign) => {
-    this.setState({
-      isCampaignDirty: true
-    });
-
+    this.props.markDirty();
     this.props.updateCampaign(newCampaign.id, newCampaign);
   }
 
@@ -41,25 +33,13 @@ class CampaignInformationEdit extends React.Component {
     }));
   }
 
-  renderSaveButtons = () => {
-    if (!this.state.isCampaignDirty) {
-      return false;
-    }
-
-    return (
-      <div className="campaign-box__footer">
-        <span className="campaign-info__button" onClick={this.triggerSave}>Save</span>
-      </div>
-    );
-  }
-
   render () {
     return (
-      <div className="campaign-info campaign-box">
-        <div className="campaign-box__header">
+      <div className="campaign-info campaign-box-section">
+        <div className="campaign-box-section__header">
           Campaign Info
         </div>
-        <div className="campaign-box__body">
+        <div className="campaign-box-section__body">
           <div className="campaign-info__field">
             <label>Name</label>
             <EditableText value={this.props.campaign.name} onChange={this.updateCampaignName} />
@@ -73,7 +53,6 @@ class CampaignInformationEdit extends React.Component {
             <EditableText value={this.props.campaign.actualValue ? "£" + this.props.campaign.actualValue : ""} onChange={this.updateCampaignValue} />
           </div>
         </div>
-        {this.renderSaveButtons()}
       </div>
     );
   }

--- a/public/components/CampaignInformationEdit/CampaignTargetsEdit.js
+++ b/public/components/CampaignInformationEdit/CampaignTargetsEdit.js
@@ -7,20 +7,13 @@ import { defaultTargets } from '../../constants/defaultTargets'
 class CampaignTargetsEdit extends React.Component {
 
   static propTypes = {
-    updateCampaign: PropTypes.func.isRequired,
-    markDirty: PropTypes.func.isRequired
+    updateCampaign: PropTypes.func.isRequired
   };
-  
-  triggerUpdate = (newCampaign) => {
-    this.props.markDirty();
-
-    this.props.updateCampaign(newCampaign.id, newCampaign);
-  }
 
   updateTargetValue = (target, number) => {
     const updatedTargets = Object.assign({}, this.props.campaign.targets, { [target]: number })
 
-    this.triggerUpdate(Object.assign({}, this.props.campaign, {
+    this.props.updateCampaign(Object.assign({}, this.props.campaign, {
       targets: updatedTargets
     }));
   }
@@ -28,7 +21,7 @@ class CampaignTargetsEdit extends React.Component {
   deleteTarget = (target) => {
     const updatedTargets = R.omit(target, this.props.campaign.targets);
 
-    this.triggerUpdate(Object.assign({}, this.props.campaign, {
+    this.props.updateCampaign(Object.assign({}, this.props.campaign, {
       targets: updatedTargets
     }));
   }

--- a/public/components/CampaignInformationEdit/CampaignTargetsEdit.js
+++ b/public/components/CampaignInformationEdit/CampaignTargetsEdit.js
@@ -1,6 +1,8 @@
 import React, { PropTypes } from 'react';
 import R from 'ramda';
+import AddTargetControl from './AddTargetControl';
 import EditableNumber from '../utils/EditableNumber';
+import { defaultTargets } from '../../constants/defaultTargets'
 
 class CampaignTargetsEdit extends React.Component {
 
@@ -39,6 +41,11 @@ class CampaignTargetsEdit extends React.Component {
     }));
   }
 
+  formatTargetName = k => {
+    const targetInfo = defaultTargets.find(t => t.value === k);
+    return targetInfo ? targetInfo.name : k;
+  }
+
   renderTargetsList = () => {
 
     const keys = Object.keys(this.props.campaign.targets).sort();
@@ -47,7 +54,7 @@ class CampaignTargetsEdit extends React.Component {
       <ul>
         {keys.map((k) =>
           <div className="campaign-info__field" key={k} >
-            <label>{k}</label>
+            <label>{ this.formatTargetName(k) }</label>
             <EditableNumber value={this.props.campaign.targets[k]} onNumberChange={this.updateTargetValue.bind(this, k)} />
             <div className="editable-text__button" onClick={this.deleteTarget.bind(this, k)} >
               <i className="i-delete"/>
@@ -68,6 +75,7 @@ class CampaignTargetsEdit extends React.Component {
           <div>
             {this.renderTargetsList()}
           </div>
+          <AddTargetControl existingTargets={Object.keys(this.props.campaign.targets)} onTargetAdded={this.updateTargetValue} />
         </div>
       </div>
     );

--- a/public/components/CampaignInformationEdit/CampaignTargetsEdit.js
+++ b/public/components/CampaignInformationEdit/CampaignTargetsEdit.js
@@ -1,0 +1,77 @@
+import React, { PropTypes } from 'react';
+import R from 'ramda';
+import EditableNumber from '../utils/EditableNumber';
+
+class CampaignTargetsEdit extends React.Component {
+
+  state = {
+    isCampaignDirty: false
+  }
+
+  triggerSave = () => {
+    this.props.saveCampaign(this.props.campaign.id, this.props.campaign);
+    this.setState({
+      isCampaignDirty: false
+    });
+  }
+
+  triggerUpdate = (newCampaign) => {
+    this.setState({
+      isCampaignDirty: true
+    });
+
+    this.props.updateCampaign(newCampaign.id, newCampaign);
+  }
+
+  updateTargetValue = (target, number) => {
+    const updatedTargets = Object.assign({}, this.props.campaign.targets, { [target]: number })
+
+    this.triggerUpdate(Object.assign({}, this.props.campaign, {
+      targets: updatedTargets
+    }));
+  }
+
+  deleteTarget = (target) => {
+    const updatedTargets = R.omit(target, this.props.campaign.targets);
+
+    this.triggerUpdate(Object.assign({}, this.props.campaign, {
+      targets: updatedTargets
+    }));
+  }
+
+  renderTargetsList = () => {
+
+    const keys = Object.keys(this.props.campaign.targets).sort();
+
+    return (
+      <ul>
+        {keys.map((k) =>
+          <div className="campaign-info__field" key={k} >
+            <label>{k}</label>
+            <EditableNumber value={this.props.campaign.targets[k]} onNumberChange={this.updateTargetValue.bind(this, k)} />
+            <div className="editable-text__button" onClick={this.deleteTarget.bind(this, k)} >
+              <i className="i-delete"/>
+            </div>
+          </div>
+        )}
+      </ul>
+    );
+  }
+  
+  render () {
+    return (
+      <div className="campaign-info campaign-box">
+        <div className="campaign-box__header">
+          Campaign Targets
+        </div>
+        <div className="campaign-box__body">
+          <div>
+            {this.renderTargetsList()}
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default CampaignTargetsEdit;

--- a/public/components/CampaignInformationEdit/CampaignTargetsEdit.js
+++ b/public/components/CampaignInformationEdit/CampaignTargetsEdit.js
@@ -6,21 +6,13 @@ import { defaultTargets } from '../../constants/defaultTargets'
 
 class CampaignTargetsEdit extends React.Component {
 
-  state = {
-    isCampaignDirty: false
-  }
-
-  triggerSave = () => {
-    this.props.saveCampaign(this.props.campaign.id, this.props.campaign);
-    this.setState({
-      isCampaignDirty: false
-    });
-  }
-
+  static propTypes = {
+    updateCampaign: PropTypes.func.isRequired,
+    markDirty: PropTypes.func.isRequired
+  };
+  
   triggerUpdate = (newCampaign) => {
-    this.setState({
-      isCampaignDirty: true
-    });
+    this.props.markDirty();
 
     this.props.updateCampaign(newCampaign.id, newCampaign);
   }
@@ -67,11 +59,11 @@ class CampaignTargetsEdit extends React.Component {
   
   render () {
     return (
-      <div className="campaign-info campaign-box">
-        <div className="campaign-box__header">
+      <div className="campaign-info campaign-box-section">
+        <div className="campaign-box-section__header">
           Campaign Targets
         </div>
-        <div className="campaign-box__body">
+        <div className="campaign-box-section__body">
           <div>
             {this.renderTargetsList()}
           </div>

--- a/public/components/CampaignInformationEdit/CampaignTargetsEdit.js
+++ b/public/components/CampaignInformationEdit/CampaignTargetsEdit.js
@@ -55,8 +55,8 @@ class CampaignTargetsEdit extends React.Component {
         {keys.map((k) =>
           <div className="campaign-info__field" key={k} >
             <label>{ this.formatTargetName(k) }</label>
-            <EditableNumber value={this.props.campaign.targets[k]} onNumberChange={this.updateTargetValue.bind(this, k)} />
-            <div className="editable-text__button" onClick={this.deleteTarget.bind(this, k)} >
+            <EditableNumber value={this.props.campaign.targets[k]} onNumberChange={ (n) => this.updateTargetValue(k, n)} />
+            <div className="editable-text__button" onClick={ () => this.deleteTarget(k) } >
               <i className="i-delete"/>
             </div>
           </div>

--- a/public/components/Main.js
+++ b/public/components/Main.js
@@ -8,7 +8,7 @@ class Main extends React.Component {
     children: React.PropTypes.element.isRequired
   }
 
-  clearError() {
+  clearError = () => {
     this.props.uiActions.clearError();
   }
 
@@ -20,7 +20,7 @@ class Main extends React.Component {
     return (
       <div className="error-bar">
         {this.props.error || 'An error has occured, please refresh your browser. If this problem persists please contact Central Production'}
-        <span className="error-bar__dismiss" onClick={this.clearError.bind(this)}>
+        <span className="error-bar__dismiss" onClick={this.clearError}>
           <i className="i-cross-grey"></i>
         </span>
       </div>

--- a/public/components/utils/EditableNumber.js
+++ b/public/components/utils/EditableNumber.js
@@ -3,7 +3,7 @@ import React, { PropTypes } from 'react';
 class EditableNumber extends React.Component {
 
   static propTypes = {
-    value: PropTypes.number.isRequired,
+    value: PropTypes.number,
     onNumberChange: PropTypes.func.isRequired
   }; 
 
@@ -46,7 +46,7 @@ class EditableNumber extends React.Component {
 
     return (
       <div className="editable-text">
-        <input className="editable-text__input" value={this.props.value} onChange={this.updateValue} />
+        <input className="editable-text__input" value={this.props.value || ""} onChange={this.updateValue} />
         <div className="editable-text__button" onClick={this.disableEditing} >
           <i className="i-cross-grey"/>
         </div>

--- a/public/components/utils/EditableNumber.js
+++ b/public/components/utils/EditableNumber.js
@@ -1,0 +1,61 @@
+import React, { PropTypes } from 'react';
+
+class EditableNumber extends React.Component {
+
+  static propTypes = {
+    value: PropTypes.number.isRequired,
+    onNumberChange: PropTypes.func.isRequired
+  }; 
+
+  state = {
+    editable: false
+  }
+
+  enableEditing = () => {
+    this.setState({
+      editable: true
+    });
+  }
+
+  disableEditing = () => {
+    this.setState({
+      editable: false
+    });
+  }
+
+  updateValue = (e) => {
+    const fieldValue = e.target.value;
+
+    if(parseInt(fieldValue) !== NaN) {
+      this.props.onNumberChange(parseInt(fieldValue));
+    }
+  }
+
+  render () {
+
+    if (!this.state.editable) {
+      return (
+        <div className="editable-text" onClick={this.enableEditing} >
+          <span className={this.props.value ? "editable-text__text" : "editable-text__text--empty"}>{this.props.value || "Empty"}</span>
+          <div className="editable-text__button" >
+            <i className="i-pen"/>
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div className="editable-text">
+        <input className="editable-text__input" value={this.props.value} onChange={this.updateValue} />
+        <div className="editable-text__button" onClick={this.disableEditing} >
+          <i className="i-cross-grey"/>
+        </div>
+      </div>
+    );
+
+  }
+}
+
+
+
+export default EditableNumber;

--- a/public/constants/defaultTargets.js
+++ b/public/constants/defaultTargets.js
@@ -1,6 +1,5 @@
 export const defaultTargets = [
   {name: 'Page views', value: 'pageviews'},
   {name: 'Qualified uniques', value: 'qualifiedUniques'},
-  {name: 'Unique users', value: 'uniques'},
-  {name: 'Custom', value: 'custom'}
+  {name: 'Unique users', value: 'uniques'}
 ];

--- a/public/constants/defaultTargets.js
+++ b/public/constants/defaultTargets.js
@@ -1,0 +1,6 @@
+export const defaultTargets = [
+  {name: 'Page views', value: 'pageviews'},
+  {name: 'Qualified uniques', value: 'qualifiedUniques'},
+  {name: 'Unique users', value: 'uniques'},
+  {name: 'Custom', value: 'custom'}
+];

--- a/public/styles/components/campaign/_campaign.scss
+++ b/public/styles/components/campaign/_campaign.scss
@@ -49,3 +49,25 @@
 
   text-align: right;
 }
+
+.campaign-box-section {
+  width: 100%;
+}
+
+.campaign-box-section__header {
+  background-color: $c-grey-200;
+  color: black;
+
+  font-size: 16px;
+  text-transform: uppercase;
+
+  padding: 10px 20px;
+}
+
+.campaign-box-section__body {
+  padding: 20px;
+
+  font-size: 14px;
+
+  border: 1px solid $c-grey-300;;
+}


### PR DESCRIPTION
Adds the ability to view, add, edit and delete campaign targets.

Small rearrangement to the campaign info edit stuff to share the save functionality (it all saves together after all)

<img width="1159" alt="screen shot 2016-09-07 at 17 18 47" src="https://cloud.githubusercontent.com/assets/145254/18320060/3caca198-7520-11e6-8be5-c7241c2dfdce.png">
