### PR TITLE
Pulls in the campaign end date from tag manager then do stuff with it

### DIFF
--- a/app/model/command/ImportCampaignFromCAPICommand.scala
+++ b/app/model/command/ImportCampaignFromCAPICommand.scala
@@ -10,7 +10,7 @@ import model._
 import org.joda.time.DateTime
 import play.api.Logger
 import play.api.libs.json.Format
-import repositories.{CampaignContentRepository, CampaignRepository, ClientRepository, ContentApi}
+import repositories._
 
 case class Section(id: Long, pathPrefix: String)
 
@@ -149,6 +149,9 @@ case class RefreshCampaignFromCAPICommand(id: String) extends CAPIImportCommand 
 
     val apiContent = ContentApi.loadAllContentInSection(campaign.pathPrefix getOrElse( CampaignMissingData("pathPrefix") ))
     val hostedTag = deriveHostedTagFromContent(apiContent) getOrElse (CampaignTagNotFound)
+    val sponsorship = campaign.tagId.flatMap( TagManagerApi.getSponsorshipForTag )
+
+    Logger.info(s"sponsorship is $sponsorship")
 
     updateCampaignAndContent(apiContent, hostedTag, campaign)
   }

--- a/app/model/external/Image.scala
+++ b/app/model/external/Image.scala
@@ -1,0 +1,17 @@
+package model.external
+
+import ai.x.play.json.Jsonx
+
+
+case class ImageAsset(imageUrl: String, width: Long, height: Long, mimeType: String)
+
+object ImageAsset {
+  implicit val imageAssetFormat = Jsonx.formatCaseClass[ImageAsset]
+}
+
+case class Image(imageId: String, assets: List[ImageAsset])
+
+object Image {
+  implicit val imageFormat = Jsonx.formatCaseClass[Image]
+}
+

--- a/app/model/external/Sponsorship.scala
+++ b/app/model/external/Sponsorship.scala
@@ -1,0 +1,31 @@
+package model.external
+
+import ai.x.play.json.Jsonx
+import org.joda.time.DateTime
+import play.api.libs.json.Format
+
+case class SponsorshipTargeting(publishedSince: Option[DateTime], validEditions: Option[List[String]])
+
+object SponsorshipTargeting {
+  implicit val sponsorshipTargetingFormat: Format[SponsorshipTargeting]  = Jsonx.formatCaseClass[SponsorshipTargeting]
+}
+
+
+case class Sponsorship (
+                         id: Long,
+                         validFrom: Option[DateTime],
+                         validTo: Option[DateTime],
+                         status: String,
+                         sponsorshipType: String,
+                         sponsorName: String,
+                         sponsorLogo: Image,
+                         highContrastSponsorLogo: Option[Image],
+                         sponsorLink: String,
+                         aboutLink: Option[String],
+                         tags: Option[List[Long]],
+                         sections: Option[List[Long]],
+                         targeting: Option[SponsorshipTargeting])
+
+object Sponsorship {
+  implicit val sponsorshipFormat: Format[Sponsorship] = Jsonx.formatCaseClass[Sponsorship]
+}

--- a/app/repositories/ContentApi.scala
+++ b/app/repositories/ContentApi.scala
@@ -5,8 +5,8 @@ import java.util.concurrent.Executors
 import com.gu.contentapi.client.ContentApiClientLogic
 import com.gu.contentapi.client.model._
 import com.gu.contentapi.client.model.v1.Content
-import com.squareup.okhttp.Credentials
 import dispatch.FunctionHandler
+import okhttp3.Credentials
 import play.api.Logger
 import services.Config
 

--- a/app/repositories/GoogleAnalytics.scala
+++ b/app/repositories/GoogleAnalytics.scala
@@ -130,7 +130,7 @@ object GoogleAnalytics {
     def addDailyTargets(dailyTarget: Option[Long]) = {
 
       val dayStatsWithTarget = dailyTarget.map{ target =>
-        dayStats.mapValues{stats => stats + ("targetUniques" -> target)}
+        dayStats.mapValues{stats => stats + ("target-uniques" -> target)}
       }.getOrElse(dayStats)
 
       ParsedDailyCountsReport(seenPaths, dayStatsWithTarget)

--- a/app/repositories/GoogleAnalytics.scala
+++ b/app/repositories/GoogleAnalytics.scala
@@ -5,7 +5,8 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
 import com.google.api.services.analyticsreporting.v4.model._
 import com.google.api.services.analyticsreporting.v4.{AnalyticsReporting, AnalyticsReportingScopes}
-import org.joda.time.DateTime
+import model.Campaign
+import org.joda.time.{DateTime, Duration}
 import org.joda.time.format.ISODateTimeFormat
 import play.api.Logger
 import play.api.libs.json.Format
@@ -19,7 +20,7 @@ import scala.collection.JavaConversions._
 case class CampaignDailyCountsReport(seenPaths: Set[String], pageCountStats: List[Map[String, Long]])
 
 object CampaignDailyCountsReport{
-  implicit val agencyFormat: Format[CampaignDailyCountsReport] = Jsonx.formatCaseClass[CampaignDailyCountsReport]
+  implicit val campaignDailyCountsReportFormat: Format[CampaignDailyCountsReport] = Jsonx.formatCaseClass[CampaignDailyCountsReport]
 
   def apply(parsedDailyCountsReport: ParsedDailyCountsReport): CampaignDailyCountsReport = {
     CampaignDailyCountsReport(
@@ -54,6 +55,9 @@ object GoogleAnalytics {
       gaFilter <- campaign.gaFilterExpression
     ) yield {
 
+
+      val dailyUniqueTargetValue = calculateDailyUniqueTarget(campaign)
+
       val endOfRange = campaign.endDate.flatMap{ed => if(ed.isBeforeNow) Some(ed.toString("yyyy-MM-dd")) else None}.getOrElse("yesterday")
       val dateRange = new DateRange().setStartDate(startDate.toString("yyyy-MM-dd")).setEndDate(endOfRange)
 
@@ -79,12 +83,25 @@ object GoogleAnalytics {
       val stats = parseDailyCountsReport(reportResponse)
         .map(_.zeroMissingPaths)
         .map(_.calulateDailyTotals)
+        .map(_.addDailyTargets(dailyUniqueTargetValue))
         .map(_.calulateCumalativeVales)
 
       stats.map(CampaignDailyCountsReport(_))
     }
 
     report.flatten
+  }
+
+
+  private def calculateDailyUniqueTarget(campaign: Campaign): Option[Long] = {
+    for(
+      startDate <- campaign.startDate;
+      endDate <- campaign.endDate;
+      target <- campaign.targets.get("uniques")
+    ) yield {
+      val days = new Duration(startDate, endDate).getStandardDays
+      target / days
+    }
   }
 
   case class ParsedDailyCountsReport(seenPaths: Set[String], dayStats: Map[DateTime, Map[String, Long]]) {
@@ -108,6 +125,15 @@ object GoogleAnalytics {
       }
 
       ParsedDailyCountsReport(seenPaths, totalisedDayStats)
+    }
+
+    def addDailyTargets(dailyTarget: Option[Long]) = {
+
+      val dayStatsWithTarget = dailyTarget.map{ target =>
+        dayStats.mapValues{stats => stats + ("targetUniques" -> target)}
+      }.getOrElse(dayStats)
+
+      ParsedDailyCountsReport(seenPaths, dayStatsWithTarget)
     }
 
     def calulateCumalativeVales = {

--- a/app/repositories/TagManagerApi.scala
+++ b/app/repositories/TagManagerApi.scala
@@ -2,22 +2,24 @@ package repositories
 
 import java.util.concurrent.TimeUnit
 
-import com.squareup.okhttp.{OkHttpClient, Request}
 import model.external.Sponsorship
+import okhttp3._
 import play.api.Logger
 import play.api.libs.json.Json
 import services.Config
 
 
+
 object TagManagerApi {
 
-  val httpClient = new OkHttpClient()
+  val httpClient = new OkHttpClient.Builder()
+    .connectTimeout(2, TimeUnit.SECONDS)
+    .build()
 
   def getSponsorshipForTag(id: Long): Option[Sponsorship] = {
 
     Logger.info(s"connecting to ${Config().tagManagerApiUrl}/hyper/tags/$id/sponsorships")
 
-    httpClient.setConnectTimeout(2, TimeUnit.SECONDS)
     val req = new Request.Builder().url(s"${Config().tagManagerApiUrl}/hyper/tags/$id/sponsorships").build
     val resp = httpClient.newCall(req).execute
 

--- a/app/repositories/TagManagerApi.scala
+++ b/app/repositories/TagManagerApi.scala
@@ -1,0 +1,36 @@
+package repositories
+
+import java.util.concurrent.TimeUnit
+
+import com.squareup.okhttp.{OkHttpClient, Request}
+import model.external.Sponsorship
+import play.api.Logger
+import play.api.libs.json.Json
+import services.Config
+
+
+object TagManagerApi {
+
+  val httpClient = new OkHttpClient()
+
+  def getSponsorshipForTag(id: Long): Option[Sponsorship] = {
+
+    Logger.info(s"connecting to ${Config().tagManagerApiUrl}/hyper/tags/$id/sponsorships")
+
+    httpClient.setConnectTimeout(2, TimeUnit.SECONDS)
+    val req = new Request.Builder().url(s"${Config().tagManagerApiUrl}/hyper/tags/$id/sponsorships").build
+    val resp = httpClient.newCall(req).execute
+
+    resp.code match {
+      case 404 => None
+      case 200 => {
+        val responseJson = Json.parse(resp.body().string())
+        (responseJson \ "data" \\ "data").headOption.map(_.as[Sponsorship])
+      }
+      case c => {
+        Logger.warn(s"failed to fetch tag sponsorship ${resp.body}")
+        throw new RuntimeException(s"failed to fetch tag sponsorship ${resp.body}")
+      }
+    }
+  }
+}

--- a/app/services/Config.scala
+++ b/app/services/Config.scala
@@ -110,7 +110,7 @@ class DevConfig extends Config {
   override def pandaDomain: String = "local.dev-gutools.co.uk"
   override def pandaAuthCallback: String = "https://campaign-central.local.dev-gutools.co.uk/oauthCallback"
 
-  override def tagManagerApiUrl = "https://tagmanager.local.dev-gutools.co.uk"
+  override def tagManagerApiUrl = "https://tagmanager.code.dev-gutools.co.uk"
   override def composerUrl = "https://composer.local.dev-gutools.co.uk"
   override def liveUrl = "https://www.theguardian.com"
   override def previewUrl = "https://viewer.gutools.co.uk/preview"

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ lazy val dependencies = Seq(
   "com.gu" % "pan-domain-auth-play_2-5_2.11" % "0.4.0",
   "com.gu" %% "content-api-client" % "10.5",
   "com.google.apis" % "google-api-services-analyticsreporting" % "v4-rev10-1.22.0",
-  "com.squareup.okhttp" % "okhttp" % "2.7.5",
+  "com.squareup.okhttp3" % "okhttp" % "3.4.1",
   ws,
   "net.logstash.logback" % "logstash-logback-encoder" % "4.7",
   "com.gu" % "kinesis-logback-appender" % "1.3.0",

--- a/public/components/CampaignAnalytics/Analytics/CampaignDailyTrafficChart.js
+++ b/public/components/CampaignAnalytics/Analytics/CampaignDailyTrafficChart.js
@@ -22,6 +22,7 @@ class CampaignDailyTrafficChart extends React.Component {
               <YAxis label="Views"/>
               <Line type="linear" dataKey="count-total" stroke={getStrokeColour(0)}  name="Page Views"/>
               <Line type="linear" dataKey="unique-total" stroke={getStrokeColour(1)} name="Uniques"/>
+              <Line type="linear" dataKey="target-uniques" stroke={getStrokeColour(2)} name="Daily target uniques" dot={false}/>
               <Tooltip labelFormatter={formatMillisecondDate} />
               <Legend />
             </LineChart>

--- a/public/components/CampaignAnalytics/Analytics/CampaignPagesCumulativeTrafficChart.js
+++ b/public/components/CampaignAnalytics/Analytics/CampaignPagesCumulativeTrafficChart.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react'
-import {AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer} from 'recharts'
+import {ComposedChart, Area, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer} from 'recharts'
 import {formatMillisecondDate, shortFormatMillisecondDate} from '../../../util/dateFormatter'
 import {formatPath, getStrokeColour, getFillColour} from '../../../util/analyticsHelper'
 import {pageCountStatPropType} from '../../../propTypes/analytics'
@@ -18,21 +18,22 @@ class CampaignPagesCumulativeTrafficChart extends React.Component {
         <div className="campaign-box__header">Cumulative uniques</div>
         <div className="campaign-box__body">
           <ResponsiveContainer height={300} width="90%">
-            <AreaChart data={this.props.pageCountStats}>
+            <ComposedChart data={this.props.pageCountStats}>
               <XAxis dataKey="date" tickFormatter={shortFormatMillisecondDate} label="Date" />
               <YAxis label="Views"/>
               <Tooltip labelFormatter={formatMillisecondDate} />
               <Legend />
+              <Line type="linear" dataKey="cumulative-target-uniques" stroke={getStrokeColour(0)} name="Target uniques" dot={false}/>
               {this.props.paths.map((p, index) =>
                 <Area key={index}
                       type='linear'
                       dataKey={'cumulative-unique' + p}
                       stackId="1"
                       name={formatPath(p)}
-                      stroke={getStrokeColour(index)}
-                      fill={getFillColour(index)} />
+                      stroke={getStrokeColour(index + 1)}
+                      fill={getFillColour(index + 1 )} />
               )}
-            </AreaChart>
+            </ComposedChart>
           </ResponsiveContainer>
         </div>
       </div>

--- a/public/components/CampaignAnalytics/Analytics/CampaignPerformanceSummary.js
+++ b/public/components/CampaignAnalytics/Analytics/CampaignPerformanceSummary.js
@@ -28,6 +28,14 @@ class CampaignPerformanceSummary extends React.Component {
       data.push( {name: "target", count: target, fill: getFillColour(index++)} );
     }
 
+    if (this.props.latestCounts["cumulative-target-uniques"]) {
+      data.push({
+        name: "target to date",
+        count: this.props.latestCounts["cumulative-target-uniques"],
+        fill: getFillColour(index++)
+      });
+    }
+
     data.push( {name: "uniques", count: this.props.latestCounts["cumulative-unique-total"], fill: getFillColour(index++)} );
 
     for(var i = 0; i < this.props.paths.length; i++) {

--- a/public/components/CampaignInformationEdit/CampaignInformationEdit.js
+++ b/public/components/CampaignInformationEdit/CampaignInformationEdit.js
@@ -51,7 +51,6 @@ class CampaignInformationEdit extends React.Component {
       const now = new Date();
       const oneDayMillis = 24 * 60 * 60 * 1000;
       const days = Math.round((this.props.campaign.endDate - now) / oneDayMillis);
-      console.log(this.props.campaign.endDate, now, oneDayMillis, days);
 
       daysLeft = ' - ' + days + ' days left';
     }

--- a/public/components/CampaignInformationEdit/CampaignInformationEdit.js
+++ b/public/components/CampaignInformationEdit/CampaignInformationEdit.js
@@ -35,6 +35,27 @@ class CampaignInformationEdit extends React.Component {
   }
 
   render () {
+
+    var startDate = 'Not yet started';
+    if (this.props.campaign.startDate) {
+      startDate = formatMillisecondDate(this.props.campaign.startDate);
+    }
+
+    var endDate = 'Not yet configured';
+    if (this.props.campaign.endDate) {
+      endDate = formatMillisecondDate(this.props.campaign.endDate);
+    }
+
+    var daysLeft = '';
+    if (this.props.campaign.startDate && this.props.campaign.endDate) {
+      const now = new Date();
+      const oneDayMillis = 24 * 60 * 60 * 1000;
+      const days = Math.round((this.props.campaign.endDate - now) / oneDayMillis);
+      console.log(this.props.campaign.endDate, now, oneDayMillis, days);
+
+      daysLeft = ' - ' + days + ' days left';
+    }
+
     return (
       <div className="campaign-info campaign-box-section">
         <div className="campaign-box-section__header">
@@ -60,6 +81,14 @@ class CampaignInformationEdit extends React.Component {
           <div className="campaign-info__field">
             <label>Status</label>
             <EditableDropdown values={campaignStatuses} name="status" selectedValue={this.props.campaign.status} onChange={this.updateCampaignStatus} />
+          </div>
+          <div className="campaign-info__field">
+            <label>Start date</label>
+            <span className="campaign-info__field__value">{startDate}</span>
+          </div>
+          <div className="campaign-info__field">
+            <label>End date</label>
+            <span className="campaign-info__field__value">{endDate}{daysLeft}</span>
           </div>
         </div>
       </div>

--- a/public/components/CampaignList/CampaignListItem.js
+++ b/public/components/CampaignList/CampaignListItem.js
@@ -23,7 +23,7 @@ class CampaignListItem extends React.Component {
       startDate = shortFormatMillisecondDate(this.props.campaign.startDate);
     }
 
-    var endDate = 'not yet configured';
+    var endDate = 'Not yet configured';
     if (this.props.campaign.endDate) {
       endDate = shortFormatMillisecondDate(this.props.campaign.endDate);
     }

--- a/public/components/CampaignList/CampaignListItem.js
+++ b/public/components/CampaignList/CampaignListItem.js
@@ -33,7 +33,6 @@ class CampaignListItem extends React.Component {
       const now = new Date();
       const oneDayMillis = 24 * 60 * 60 * 1000;
       const days = Math.round((this.props.campaign.endDate - now) / oneDayMillis);
-      console.log(this.props.campaign.endDate, now, oneDayMillis, days);
 
       daysLeft = ' - ' + days + ' days left';
     }

--- a/public/components/CampaignList/CampaignListItem.js
+++ b/public/components/CampaignList/CampaignListItem.js
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import {Link} from 'react-router';
+import {formatMillisecondDate, shortFormatMillisecondDate} from '../../util/dateFormatter'
 
 class CampaignListItem extends React.Component {
 
@@ -17,6 +18,26 @@ class CampaignListItem extends React.Component {
       image = <img src={this.props.campaign.campaignLogo} className="campaign-list__item__logo"/>
     }
 
+    var startDate = 'Not yet started';
+    if (this.props.campaign.startDate) {
+      startDate = shortFormatMillisecondDate(this.props.campaign.startDate);
+    }
+
+    var endDate = 'not yet configured';
+    if (this.props.campaign.endDate) {
+      endDate = shortFormatMillisecondDate(this.props.campaign.endDate);
+    }
+
+    var daysLeft = '';
+    if (this.props.campaign.startDate && this.props.campaign.endDate) {
+      const now = new Date();
+      const oneDayMillis = 24 * 60 * 60 * 1000;
+      const days = Math.round((this.props.campaign.endDate - now) / oneDayMillis);
+      console.log(this.props.campaign.endDate, now, oneDayMillis, days);
+
+      daysLeft = ' - ' + days + ' days left';
+    }
+
     return (
       <Link className="campaign-list__item" to={"/campaign/" + this.props.campaign.id}>
           {image}
@@ -32,11 +53,11 @@ class CampaignListItem extends React.Component {
           </span>
           <span className="campaign-list__item__info-other">
             <span className="campaign-list__item__info-other--info">Start date: </span>
-            <span className="campaign-list__item__info-other--value">13.08.2016 </span>
+            <span className="campaign-list__item__info-other--value">{startDate}</span>
           </span>
           <span className="campaign-list__item__info-other">
                 <span className="campaign-list__item__info-other--info">Finish date: </span>
-                <span className="campaign-list__item__info-other--value">13.11.2016 - 55 days left</span>
+                <span className="campaign-list__item__info-other--value">{endDate}{daysLeft}</span>
           </span>
         </div>
       </Link>


### PR DESCRIPTION
Show dates on the campaign list - including days left to run

<img width="259" alt="screen shot 2016-10-21 at 16 20 54" src="https://cloud.githubusercontent.com/assets/145254/19603852/93953964-97aa-11e6-9912-b032b6b2a584.png">

And show then on campaign details page

<img width="356" alt="screen shot 2016-10-21 at 16 21 08" src="https://cloud.githubusercontent.com/assets/145254/19603859/a1f53f0e-97aa-11e6-9f1c-b07b18d3d1cd.png">

Use the dates to work out how many unigues should have been served to date and show that on the rainbow (tm)

<img width="1135" alt="screen shot 2016-10-21 at 16 21 22" src="https://cloud.githubusercontent.com/assets/145254/19603879/bcbdd8a0-97aa-11e6-87d7-409948a499b7.png">

and finally put lines on the daily and cumulative page view charts

<img width="1140" alt="screen shot 2016-10-21 at 16 21 32" src="https://cloud.githubusercontent.com/assets/145254/19604013/6148687c-97ab-11e6-9598-2ae1ebc067c8.png">
