### PR TITLE
Show daily traffic driver stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,13 @@
 target/
 project/boot/
+project/project/
 
 .idea/
 .idea_modules/
 
 node_modules/
 
-logs/*
+logs/
 
 .history
 

--- a/app/model/TrafficDriver.scala
+++ b/app/model/TrafficDriver.scala
@@ -8,6 +8,8 @@ import services.Config.conf._
 import services.{DfpFetcher, DfpFilter}
 import util.AnalyticsCache
 
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 import scala.io.BufferedSource
 
 case class PerformanceStats(impressions: Int, clicks: Int) {
@@ -133,7 +135,7 @@ object TrafficDriverGroupStats {
   def forCampaign(campaignId: String): Seq[TrafficDriverGroupStats] = {
     val cachedStats = statsCache.get(campaignId) getOrElse Nil
     if (cachedStats.isEmpty) {
-      loadStatsForCampaign(campaignId)
+      Future(loadStatsForCampaign(campaignId))
     }
     cachedStats
   }

--- a/app/services/Dfp.scala
+++ b/app/services/Dfp.scala
@@ -3,12 +3,22 @@ package services
 import com.google.api.ads.common.lib.auth.OfflineCredentials
 import com.google.api.ads.common.lib.auth.OfflineCredentials.Api._
 import com.google.api.ads.dfp.axis.factory.DfpServices
-import com.google.api.ads.dfp.axis.utils.v201608.StatementBuilder
-import com.google.api.ads.dfp.axis.v201608._
+import com.google.api.ads.dfp.axis.utils.v201608.{ReportDownloader, StatementBuilder}
+import com.google.api.ads.dfp.axis.v201608.Column._
+import com.google.api.ads.dfp.axis.v201608.DateRangeType.REACH_LIFETIME
+import com.google.api.ads.dfp.axis.v201608.Dimension._
+import com.google.api.ads.dfp.axis.v201608.ExportFormat._
+import com.google.api.ads.dfp.axis.v201608.{ReportDownloadOptions, ReportJob, ReportQuery, ReportServiceInterface, _}
 import com.google.api.ads.dfp.lib.client.DfpSession
+import play.api.Logger
 import services.Config.conf._
 
+import scala.io.{BufferedSource, Source}
+import scala.util.{Failure, Success, Try}
+
 object DfpFetcher {
+
+  System.setProperty("api.dfp.soapRequestTimeout", "300000")
 
   def mkSession(): DfpSession = {
     new DfpSession.Builder()
@@ -25,8 +35,10 @@ object DfpFetcher {
     .build()
   }
 
-  def fetchLineItemsByOrder(session: DfpSession, orderId: Long): Seq[LineItem] =
-    fetchLineItems(
+  def fetchLineItemsByOrder(session: DfpSession, orderId: Long): Seq[LineItem] = {
+
+    val start = System.currentTimeMillis
+    val lineItems = fetchLineItems(
       session,
       new StatementBuilder()
       .where("orderId = :orderId")
@@ -34,14 +46,82 @@ object DfpFetcher {
       .toStatement
     )
 
-  private def fetchLineItems(session: DfpSession, statement: Statement): Seq[LineItem] = {
+    lineItems match {
+      case Failure(e) =>
+        Logger.error(s"Fetching line items for order $orderId failed: ${e.getMessage}")
+      case Success(items) =>
+        Logger.info(s"Fetched ${items.size} line items for order $orderId in ${System.currentTimeMillis - start} ms")
+    }
 
+    lineItems getOrElse Nil
+  }
+
+  private def fetchLineItems(session: DfpSession, statement: Statement): Try[Seq[LineItem]] = {
     val lineItemService = new DfpServices().get(session, classOf[LineItemServiceInterface])
+    Try(lineItemService.getLineItemsByStatement(statement)) map { page =>
 
-    val lineItemPage = lineItemService.getLineItemsByStatement(statement)
+      // assuming only one page of results
+      page.getResults.toSeq
+    }
+  }
 
-    // assuming only one page of results
-    lineItemPage.getResults.toSeq
+  def fetchStatsReport(session: DfpSession, lineItemIds: Seq[Long]): Option[BufferedSource] = {
+
+    if (lineItemIds.isEmpty) None
+
+    else {
+
+      val qry = new ReportQuery()
+      qry.setDateRangeType(REACH_LIFETIME)
+      qry.setStatement(
+        new StatementBuilder()
+        .where(s"LINE_ITEM_ID IN (${lineItemIds.mkString(",")})")
+        .toStatement
+      )
+      qry.setDimensions(Array(DATE))
+      qry.setColumns(
+        Array(
+          TOTAL_INVENTORY_LEVEL_IMPRESSIONS,
+          TOTAL_INVENTORY_LEVEL_CLICKS
+        )
+      )
+
+      val start = System.currentTimeMillis
+      val report = fetchReport(session, qry)
+      report match {
+        case Failure(e) =>
+          Logger.error(s"Stats report on line items ${lineItemIds.mkString(", ")} failed: ${e.getMessage}")
+        case Success(_) =>
+          Logger.info(
+            s"Stats report on line items ${lineItemIds.mkString(", ")} took ${System.currentTimeMillis - start} ms"
+          )
+      }
+      report.toOption
+    }
+  }
+
+  private def fetchReport(session: DfpSession, qry: ReportQuery): Try[BufferedSource] = {
+
+    val reportService = new DfpServices().get(session, classOf[ReportServiceInterface])
+
+    val reportJob = {
+      val job = new ReportJob()
+      job.setReportQuery(qry)
+      reportService.runReportJob(job)
+    }
+
+    val reportDownloader = new ReportDownloader(reportService, reportJob.getId)
+    Try(reportDownloader.waitForReportReady()) map { completed =>
+
+      val source = {
+        val options = new ReportDownloadOptions()
+        options.setExportFormat(CSV_DUMP)
+        options.setUseGzipCompression(false)
+        reportDownloader.getDownloadUrl(options)
+      }
+
+      Source.fromURL(source)
+    }
   }
 }
 

--- a/conf/routes
+++ b/conf/routes
@@ -28,6 +28,7 @@ PUT /api/campaigns/:id/note/:date         controllers.CampaignApi.updateCampaign
 POST /api/campaigns/import                controllers.CampaignApi.importFromTag()
 POST /api/campaigns/:id/refreshFromCAPI   controllers.CampaignApi.refreshCampaignFromCAPI(id: String)
 GET /api/campaigns/:id/drivers            controllers.CampaignApi.getCampaignTrafficDrivers(id: String)
+GET /api/campaigns/:id/driverstats        controllers.CampaignApi.getCampaignTrafficDriverStats(id: String)
 
 
 #Clients Api

--- a/public/actions/CampaignActions/getCampaignTrafficDriverStats.js
+++ b/public/actions/CampaignActions/getCampaignTrafficDriverStats.js
@@ -1,0 +1,37 @@
+import {fetchCampaignTrafficDriverStats} from "../../services/CampaignsApi";
+
+function requestCampaignTrafficDriverStats(id) {
+  return {
+    type: 'TRAFFIC_DRIVER_STATS_GET_REQUEST',
+    id: id,
+    receivedAt: Date.now()
+  };
+}
+
+function receiveCampaignTrafficDriverStats(trafficDriverStats) {
+  return {
+    type: 'TRAFFIC_DRIVER_STATS_GET_RECEIVE',
+    campaignTrafficDriverStats: trafficDriverStats,
+    receivedAt: Date.now()
+  };
+}
+
+function errorReceivingCampaignTrafficDriverStats(error) {
+  return {
+    type: 'SHOW_ERROR',
+    message: 'Could not get traffic driver stats',
+    error: error,
+    receivedAt: Date.now()
+  };
+}
+
+export function getCampaignTrafficDriverStats(id) {
+  return dispatch => {
+    dispatch(requestCampaignTrafficDriverStats(id));
+    return fetchCampaignTrafficDriverStats(id)
+      .catch(error => dispatch(errorReceivingCampaignTrafficDriverStats(error)))
+      .then(res => {
+        dispatch(receiveCampaignTrafficDriverStats(res));
+      });
+  };
+}

--- a/public/components/CampaignAnalytics/Analytics/CampaignTrafficDriverStatsChart.js
+++ b/public/components/CampaignAnalytics/Analytics/CampaignTrafficDriverStatsChart.js
@@ -1,0 +1,172 @@
+import React, {PropTypes} from "react";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+  ReferenceLine,
+  Brush
+} from "recharts";
+import {connect} from "react-redux";
+import {bindActionCreators} from "redux";
+import * as getCampaignTrafficDriverStats from "../../../actions/CampaignActions/getCampaignTrafficDriverStats";
+
+class CampaignTrafficDriverStatsChart extends React.Component {
+
+  componentWillMount() {
+    this.props.campaignTrafficDriverStatsActions.getCampaignTrafficDriverStats(this.props.campaign.id);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.campaign.id !== this.props.campaign.id) {
+      this.props.campaignTrafficDriverStatsActions.getCampaignTrafficDriverStats(this.props.campaign.id);
+    }
+  }
+
+  renderDriverGroupChart = (group) => {
+
+    const data = group.dayStats.map((day) => {
+      return (
+      {
+        date: day.date,
+        impressions: day.stats.impressions,
+        clicks: day.stats.clicks,
+        ctr: Math.round(day.stats.ctr * 100) / 100
+      }
+      );
+    });
+
+    const anchorName = group.groupName.toLowerCase().split(' ').join('-') + '-drivers';
+
+    const shortDateFormat = (date) => {
+      return new Date(date).toLocaleDateString('en-GB', {day: '2-digit', month: '2-digit'})
+    };
+
+    const longerDateFormat = (date) => {
+      return new Date(date).toLocaleDateString('en-GB', {weekday: 'short', day: '2-digit', month: 'short'})
+    };
+
+    const numFormat = (num) => {
+      return num.toLocaleString();
+    };
+
+    const percentFormat = (num) => {
+      return num.toLocaleString() + '%';
+    };
+
+    const containerWidth = '95%';
+    const chartWidth = 600;
+    const chartHeight = 200;
+    const chartMargin = {top: 15, right: 10, left: 10, bottom: 0};
+    const xPadding = {left: 20, right: 20};
+
+    if (group.dayStats.length == 0) {
+      return (
+        <div key={group.groupName} className="analytics-chart--half-width">
+          <a name={anchorName}/>
+          <div className="campaign-box__header">{group.groupName}</div>
+          <div className="campaign-box__body">
+            <span className="campaign-assets__field__value">No data yet.</span>
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div key={group.groupName} className="analytics-chart--half-width">
+        <a name={anchorName}/>
+        <div className="campaign-box__header">{group.groupName}</div>
+        <div className="campaign-box__body">
+          <p>Impressions</p>
+          <ResponsiveContainer height={chartHeight} width={containerWidth}>
+            <LineChart width={chartWidth} height={chartHeight} data={data} syncId={group.groupName}
+                       margin={chartMargin}>
+              <XAxis dataKey="date" tickFormatter={shortDateFormat} padding={xPadding}/>
+              <YAxis tickFormatter={numFormat}/>
+              <CartesianGrid strokeDasharray="3 3"/>
+              <Tooltip labelFormatter={longerDateFormat} formatter={numFormat}/>
+              <Line type="monotone" dataKey="impressions" stroke="#8884d8" fill="#8884d8"/>
+            </LineChart>
+          </ResponsiveContainer>
+          <p>Clicks</p>
+          <ResponsiveContainer height={chartHeight} width={containerWidth}>
+            <LineChart width={chartWidth} height={chartHeight} data={data} syncId={group.groupName}
+                       margin={chartMargin}>
+              <XAxis dataKey="date" tickFormatter={shortDateFormat} padding={xPadding}/>
+              <YAxis tickFormatter={numFormat}/>
+              <CartesianGrid strokeDasharray="3 3"/>
+              <Tooltip labelFormatter={longerDateFormat} formatter={numFormat}/>
+              <Line type="monotone" dataKey="clicks" stroke="#82ca9d" fill="#82ca9d"/>
+            </LineChart>
+          </ResponsiveContainer>
+          <p>CTR (%)</p>
+          <ResponsiveContainer height={chartHeight} width={containerWidth}>
+            <LineChart width={chartWidth} height={chartHeight} data={data} syncId={group.groupName}
+                       margin={chartMargin}>
+              <XAxis dataKey="date" tickFormatter={shortDateFormat} padding={xPadding}/>
+              <YAxis/>
+              <CartesianGrid strokeDasharray="3 3"/>
+              <Tooltip labelFormatter={longerDateFormat} formatter={percentFormat}/>
+              <Line type="monotone" dataKey="ctr" name="CTR" stroke="#993399" fill="#993399"/>
+              <Brush dataKey="date" tickFormatter={shortDateFormat} startIndex={data.length - 7}/>
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+    );
+  };
+
+  render() {
+
+    if (!this.props.campaignTrafficDriverStats) {
+      return (
+        <div className="analytics-chart--full-width">
+          <div className="campaign-box__header">Traffic Driver Performance
+            <span className="campaign-driver-list__link"><a href="#driver-summary">Back to summary</a></span>
+          </div>
+          <ProgressSpinner />
+        </div>
+      );
+    }
+
+    if (this.props.campaignTrafficDriverStats.length > 0) {
+      return (
+        <div className="analytics-chart--full-width">
+          <div className="campaign-box__header">Traffic Driver Performance
+            <span className="campaign-driver-list__link"><a href="#driver-summary">Back to summary</a></span>
+          </div>
+          {this.props.campaignTrafficDriverStats.map(this.renderDriverGroupChart)}
+        </div>
+      );
+    }
+
+    return (
+      <div className="analytics-chart--full-width">
+        <div className="campaign-box__header">Traffic Driver Performance
+          <span className="campaign-driver-list__link"><a href="#driver-summary">Back to summary</a></span>
+        </div>
+        <span className="campaign-assets__field__value">No traffic driver data to show.</span>
+      </div>
+    );
+  }
+}
+
+//REDUX CONNECTIONS
+
+function mapStateToProps(state) {
+  return {
+    campaignTrafficDriverStats: state.campaignTrafficDriverStats
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    campaignTrafficDriverStatsActions: bindActionCreators(Object.assign({}, getCampaignTrafficDriverStats), dispatch)
+  };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(CampaignTrafficDriverStatsChart);

--- a/public/components/CampaignAnalytics/Analytics/CampaignTrafficDriverStatsChart.js
+++ b/public/components/CampaignAnalytics/Analytics/CampaignTrafficDriverStatsChart.js
@@ -11,6 +11,7 @@ import {
   ReferenceLine,
   Brush
 } from "recharts";
+import {ddmmFormatDate, dddddmmmFormatDate} from "../../../util/dateFormatter";
 import {connect} from "react-redux";
 import {bindActionCreators} from "redux";
 import * as getCampaignTrafficDriverStats from "../../../actions/CampaignActions/getCampaignTrafficDriverStats";
@@ -41,14 +42,6 @@ class CampaignTrafficDriverStatsChart extends React.Component {
     });
 
     const anchorName = group.groupName.toLowerCase().split(' ').join('-') + '-drivers';
-
-    const shortDateFormat = (date) => {
-      return new Date(date).toLocaleDateString('en-GB', {day: '2-digit', month: '2-digit'})
-    };
-
-    const longerDateFormat = (date) => {
-      return new Date(date).toLocaleDateString('en-GB', {weekday: 'short', day: '2-digit', month: 'short'})
-    };
 
     const numFormat = (num) => {
       return num.toLocaleString();
@@ -85,10 +78,10 @@ class CampaignTrafficDriverStatsChart extends React.Component {
           <ResponsiveContainer height={chartHeight} width={containerWidth}>
             <LineChart width={chartWidth} height={chartHeight} data={data} syncId={group.groupName}
                        margin={chartMargin}>
-              <XAxis dataKey="date" tickFormatter={shortDateFormat} padding={xPadding}/>
+              <XAxis dataKey="date" tickFormatter={ddmmFormatDate} padding={xPadding}/>
               <YAxis tickFormatter={numFormat}/>
               <CartesianGrid strokeDasharray="3 3"/>
-              <Tooltip labelFormatter={longerDateFormat} formatter={numFormat}/>
+              <Tooltip labelFormatter={dddddmmmFormatDate} formatter={numFormat}/>
               <Line type="monotone" dataKey="impressions" stroke="#8884d8" fill="#8884d8"/>
             </LineChart>
           </ResponsiveContainer>
@@ -96,10 +89,10 @@ class CampaignTrafficDriverStatsChart extends React.Component {
           <ResponsiveContainer height={chartHeight} width={containerWidth}>
             <LineChart width={chartWidth} height={chartHeight} data={data} syncId={group.groupName}
                        margin={chartMargin}>
-              <XAxis dataKey="date" tickFormatter={shortDateFormat} padding={xPadding}/>
+              <XAxis dataKey="date" tickFormatter={ddmmFormatDate} padding={xPadding}/>
               <YAxis tickFormatter={numFormat}/>
               <CartesianGrid strokeDasharray="3 3"/>
-              <Tooltip labelFormatter={longerDateFormat} formatter={numFormat}/>
+              <Tooltip labelFormatter={dddddmmmFormatDate} formatter={numFormat}/>
               <Line type="monotone" dataKey="clicks" stroke="#82ca9d" fill="#82ca9d"/>
             </LineChart>
           </ResponsiveContainer>
@@ -107,12 +100,12 @@ class CampaignTrafficDriverStatsChart extends React.Component {
           <ResponsiveContainer height={chartHeight} width={containerWidth}>
             <LineChart width={chartWidth} height={chartHeight} data={data} syncId={group.groupName}
                        margin={chartMargin}>
-              <XAxis dataKey="date" tickFormatter={shortDateFormat} padding={xPadding}/>
+              <XAxis dataKey="date" tickFormatter={ddmmFormatDate} padding={xPadding}/>
               <YAxis/>
               <CartesianGrid strokeDasharray="3 3"/>
-              <Tooltip labelFormatter={longerDateFormat} formatter={percentFormat}/>
+              <Tooltip labelFormatter={dddddmmmFormatDate} formatter={percentFormat}/>
               <Line type="monotone" dataKey="ctr" name="CTR" stroke="#993399" fill="#993399"/>
-              <Brush dataKey="date" tickFormatter={shortDateFormat} startIndex={data.length - 7}/>
+              <Brush dataKey="date" tickFormatter={ddmmFormatDate} startIndex={data.length - 7}/>
             </LineChart>
           </ResponsiveContainer>
         </div>

--- a/public/components/CampaignAnalytics/CampaignAnalytics.js
+++ b/public/components/CampaignAnalytics/CampaignAnalytics.js
@@ -1,8 +1,9 @@
-import React, { PropTypes } from 'react'
-import CampaignPerformanceSummary from './Analytics/CampaignPerformanceSummary'
-import CampaignDailyTrafficChart from './Analytics/CampaignDailyTrafficChart'
-import CampaignPagesCumulativeTrafficChart from './Analytics/CampaignPagesCumulativeTrafficChart'
-import ContentTrafficChart from './Analytics/ContentTrafficChart'
+import React, {PropTypes} from "react";
+import CampaignPerformanceSummary from "./Analytics/CampaignPerformanceSummary";
+import CampaignDailyTrafficChart from "./Analytics/CampaignDailyTrafficChart";
+import CampaignPagesCumulativeTrafficChart from "./Analytics/CampaignPagesCumulativeTrafficChart";
+import ContentTrafficChart from "./Analytics/ContentTrafficChart";
+import CampaignTrafficDriverStatsChart from "./Analytics/CampaignTrafficDriverStatsChart";
 
 class CampaignAnalytics extends React.Component {
 
@@ -30,7 +31,7 @@ class CampaignAnalytics extends React.Component {
     if(this.props.campaignAnalytics) {
       return this.props.campaignAnalytics.pageCountStats[this.props.campaignAnalytics.pageCountStats.length - 1];
     }
-    
+
     return undefined;
   }
 
@@ -44,14 +45,21 @@ class CampaignAnalytics extends React.Component {
     }
 
     return (
-      <div className="campaign-info__body">
-        
-        <CampaignPerformanceSummary campaign={this.props.campaign} paths={this.props.campaignAnalytics.seenPaths} latestCounts={this.getLatestCounts()} />
-        <CampaignDailyTrafficChart pageCountStats={this.props.campaignAnalytics.pageCountStats} />
-        <CampaignPagesCumulativeTrafficChart pageCountStats={this.props.campaignAnalytics.pageCountStats} paths={this.props.campaignAnalytics.seenPaths}/>
-        {this.props.campaignAnalytics.seenPaths.map((p) =>
-          <ContentTrafficChart key={p} pageCountStats={this.props.campaignAnalytics.pageCountStats} path={p} />
-        )}
+      <div>
+        <div className="campaign-info__body">
+
+          <CampaignPerformanceSummary campaign={this.props.campaign} paths={this.props.campaignAnalytics.seenPaths}
+                                      latestCounts={this.getLatestCounts()}/>
+          <CampaignDailyTrafficChart pageCountStats={this.props.campaignAnalytics.pageCountStats}/>
+          <CampaignPagesCumulativeTrafficChart pageCountStats={this.props.campaignAnalytics.pageCountStats}
+                                               paths={this.props.campaignAnalytics.seenPaths}/>
+          {this.props.campaignAnalytics.seenPaths.map((p) =>
+            <ContentTrafficChart key={p} pageCountStats={this.props.campaignAnalytics.pageCountStats} path={p}/>
+          )}
+        </div>
+        <div className="campaign-info__body">
+          <CampaignTrafficDriverStatsChart campaign={this.props.campaign}/>
+        </div>
       </div>
     );
   }

--- a/public/components/CampaignInformationEdit/CampaignTrafficDrivers.js
+++ b/public/components/CampaignInformationEdit/CampaignTrafficDrivers.js
@@ -25,20 +25,27 @@ class CampaignTrafficDrivers extends React.Component {
   };
 
   renderTrafficDriverGroup = (group) => {
+
+    const dateFormat = (date) => {
+      return new Date(date).toLocaleDateString('en-GB', {day: '2-digit', month: 'short', year: 'numeric'})
+    };
+
+    const href = '#' + group.groupName.toLowerCase().split(' ').join('-') + '-drivers';
+
     return (
       <div key={group.groupName} className="campaign-driver-list__item">
         <div className="campaign-driver-list__row">
           <div className="campaign-driver-list__type">{group.groupName}</div>
-          <div className="campaign-driver-list__date">{group.startDate}</div>
-          <div className="campaign-driver-list__date">{group.endDate}</div>
+          <div className="campaign-driver-list__date">{dateFormat(group.startDate)}</div>
+          <div className="campaign-driver-list__date">{dateFormat(group.endDate)}</div>
           <div className="campaign-driver-list__stat">
-            <a href="TODO">{group.summaryStats.impressions}</a>
+            <a href={href}>{group.summaryStats.impressions.toLocaleString()}</a>
           </div>
           <div className="campaign-driver-list__stat">
-            <a href="TODO">{group.summaryStats.clicks}</a>
+            <a href={href}>{group.summaryStats.clicks.toLocaleString()}</a>
           </div>
           <div className="campaign-driver-list__stat">
-            <a href="TODO">{group.summaryStats.ctr.toFixed(2)}%</a>
+            <a href={href}>{group.summaryStats.ctr.toFixed(2)}%</a>
           </div>
           <div className="campaign-driver-list__links">{group.trafficDriverUrls.map( this.renderLineItemLink )}</div>
         </div>
@@ -70,13 +77,14 @@ class CampaignTrafficDrivers extends React.Component {
     }
 
     return (
-      <span className="campaign-assets__field__value">No traffic drivers have been created yet</span>
+      <span className="campaign-assets__field__value">No traffic drivers have been created yet.</span>
     )
   };
 
   render() {
     return (
       <div className="campaign-info campaign-box">
+        <a name="driver-summary"/>
         <div className="campaign-box__header">Traffic Drivers</div>
         <div className="campaign-box__body">
           {this.renderTrafficDriverGroups()}
@@ -90,7 +98,7 @@ class CampaignTrafficDrivers extends React.Component {
 
 function mapStateToProps(state) {
   return {
-    campaignTrafficDrivers: state.campaignTrafficDrivers,
+    campaignTrafficDrivers: state.campaignTrafficDrivers
   };
 }
 

--- a/public/propTypes/trafficDrivers.js
+++ b/public/propTypes/trafficDrivers.js
@@ -1,0 +1,8 @@
+import {PropTypes} from "react";
+
+export const trafficDriverStatPropType = PropTypes.shape({
+  date: PropTypes.number,
+  "impressions": PropTypes.number,
+  "clicks": PropTypes.number,
+  "ctr": PropTypes.number
+});

--- a/public/reducers/campaignTrafficDriverStatsReducer.js
+++ b/public/reducers/campaignTrafficDriverStatsReducer.js
@@ -1,0 +1,10 @@
+export default function campaignTrafficDriverStats(state = [], action) {
+  switch (action.type) {
+
+    case 'TRAFFIC_DRIVER_STATS_GET_RECEIVE':
+      return action.campaignTrafficDriverStats || [];
+
+    default:
+      return state;
+  }
+}

--- a/public/reducers/rootReducer.js
+++ b/public/reducers/rootReducer.js
@@ -8,6 +8,7 @@ import clients from './clientsReducer';
 import client from './clientReducer';
 import campaignContent from './campaignContentReducer';
 import campaignTrafficDrivers from './campaignTrafficDriverReducer';
+import campaignTrafficDriverStats from './campaignTrafficDriverStatsReducer';
 import campaignNotes from './campaignNotesReducer';
 
 export default combineReducers({
@@ -20,5 +21,6 @@ export default combineReducers({
   client,
   campaignContent,
   campaignTrafficDrivers,
+  campaignTrafficDriverStats,
   campaignNotes
 });

--- a/public/services/CampaignsApi.js
+++ b/public/services/CampaignsApi.js
@@ -49,6 +49,14 @@ export function fetchCampaignTrafficDrivers(id) {
   });
 }
 
+export function fetchCampaignTrafficDriverStats(id) {
+  return AuthedReqwest({
+    url: '/api/campaigns/' + id + '/driverstats',
+    contentType: 'application/json',
+    method: 'get'
+  });
+}
+
 export function fetchCampaignNotes(id) {
   return AuthedReqwest({
     url: '/api/campaigns/' + id + '/notes',

--- a/public/styles/components/campaign-traffic-drivers/_campaign-traffic-drivers.scss
+++ b/public/styles/components/campaign-traffic-drivers/_campaign-traffic-drivers.scss
@@ -44,3 +44,8 @@
 .campaign-driver-list__stat--header {
   width: 15%;
 }
+
+.campaign-driver-list__link {
+  font-size: 75%;
+  float: right;
+}

--- a/public/util/dateFormatter.js
+++ b/public/util/dateFormatter.js
@@ -11,3 +11,13 @@ export function shortFormatMillisecondDate(msDate) {
 
   return date.toLocaleDateString();
 }
+
+// 'dd/mm' eg '02/11'
+export function ddmmFormatDate(date) {
+  return new Date(date).toLocaleDateString('en-GB', {day: '2-digit', month: '2-digit'})
+}
+
+// 'ddd, dd mmm' eg 'Wed, 02 Nov'
+export function dddddmmmFormatDate(date) {
+  return new Date(date).toLocaleDateString('en-GB', {weekday: 'short', day: '2-digit', month: 'short'})
+}


### PR DESCRIPTION
Now adds a component to the end of the campaign analytics showing stats for traffic driver impressions, clicks and CTRs by type of driver, linked to from the stats summary box:

![image](https://cloud.githubusercontent.com/assets/1722550/19896529/8e84ccaa-a04c-11e6-94c8-ccceaefb93b3.png)

/cc @steppenwells 