### PR TITLE
Sw analytics summary

### DIFF
--- a/app/controllers/CampaignApi.scala
+++ b/app/controllers/CampaignApi.scala
@@ -19,6 +19,10 @@ class CampaignApi(override val wsClient: WSClient) extends Controller with Panda
     Ok(Json.toJson(CampaignRepository.getAllCampaigns()))
   }
 
+  def getAnalyticsSummary() = APIAuthAction { req =>
+    Ok(Json.toJson(AnalyticsDataCache.getOverallSummary().getOrElse(Map())))
+  }
+
   def getCampaign(id: String) = APIAuthAction { req =>
     CampaignRepository.getCampaign(id) map { c => Ok(Json.toJson(c))} getOrElse NotFound
   }

--- a/app/repositories/AnalyticsDataCache.scala
+++ b/app/repositories/AnalyticsDataCache.scala
@@ -11,7 +11,7 @@ import util.Compression
 import scala.util.control.NonFatal
 import scala.collection.JavaConversions._
 
-abstract sealed trait CacheResult[+A] extends Product {
+sealed trait CacheResult[+A] extends Product {
 
   def isEmpty: Boolean
 
@@ -97,14 +97,14 @@ object AnalyticsDataCache {
     Dynamo.analyticsDataCacheTable.deleteItem("key", key, "dataType", dataType)
   }
 
-  def putCampaignDailyCountsReport(campaignId: String, data: CampaignDailyCountsReport, expires: Option[Long]): Unit = {
-    
-    val entry = AnalyticsDataCacheEntry(campaignId, "CampaignDailyCountsReport", Json.toJson(data).toString(), expires, System.currentTimeMillis())
+  def putCampaignDailyCountsReport(campaignId: String, data: CampaignDailyCountsReport, validToTimestamp: Option[Long]): Unit = {
+
+    val entry = AnalyticsDataCacheEntry(campaignId, "CampaignDailyCountsReport", Json.toJson(data).toString(), validToTimestamp, System.currentTimeMillis())
     Dynamo.analyticsDataCacheTable.putItem(entry.toItem)
   }
 
-  def putCampaignSummary(campaignId: String, data: CampaignSummary, expires: Option[Long]): Unit = {
-    val entry = AnalyticsDataCacheEntry(campaignId, "CampaignSummary", Json.toJson(data).toString(), expires, System.currentTimeMillis())
+  def putCampaignSummary(campaignId: String, data: CampaignSummary, validToTimestamp: Option[Long]): Unit = {
+    val entry = AnalyticsDataCacheEntry(campaignId, "CampaignSummary", Json.toJson(data).toString(), validToTimestamp, System.currentTimeMillis())
     Dynamo.analyticsDataCacheTable.putItem(entry.toItem)
   }
 

--- a/app/repositories/GoogleAnalytics.scala
+++ b/app/repositories/GoogleAnalytics.scala
@@ -106,7 +106,16 @@ object GoogleAnalytics {
     val totalUniques = mostRecentStats.getOrElse("cumulative-unique-total", 0L)
     val targetToDate = mostRecentStats.getOrElse("cumulative-target-uniques", 0L)
 
-    AnalyticsDataCache.putCampaignSummary(campaignId, CampaignSummary(totalUniques, targetToDate), expiry)
+    val campaignSummary = CampaignSummary(totalUniques, targetToDate)
+    AnalyticsDataCache.putCampaignSummary(campaignId, campaignSummary, expiry)
+
+    updateOverallSummary(campaignId, campaignSummary)
+  }
+
+  private def updateOverallSummary(campaignId: String, campaignSummary: CampaignSummary): Unit = {
+    val overallSummary = AnalyticsDataCache.getOverallSummary().getOrElse(Map())
+
+    AnalyticsDataCache.putOverallSummary(overallSummary + (campaignId -> campaignSummary))
   }
 
   private def cleanAndConvertRawDailyCounts(rawDailyCounts: ParsedDailyCountsReport, dailyUniqueTargetValue: Option[Long]): CampaignDailyCountsReport = {

--- a/app/repositories/GoogleAnalytics.scala
+++ b/app/repositories/GoogleAnalytics.scala
@@ -37,6 +37,12 @@ object CampaignDailyCountsReport{
   }
 }
 
+case class CampaignSummary(totalUniques: Long, targetToDate: Long)
+
+object CampaignSummary{
+  implicit val campaignSummaryFormat: Format[CampaignSummary] = Jsonx.formatCaseClass[CampaignSummary]
+}
+
 object GoogleAnalytics {
 
   implicit val ec = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(10))
@@ -87,9 +93,20 @@ object GoogleAnalytics {
       val expiry = if(campaignFinished.getOrElse(false)) None else { Some( DateTime.now().withTimeAtStartOfDay().plusDays(1).getMillis) }
 
       AnalyticsDataCache.putCampaignDailyCountsReport(campaignId, data, expiry)
+
+      storeSummaryForCampaign(campaignId, data, expiry)
     }
 
     report
+  }
+
+  private def storeSummaryForCampaign(campaignId: String, report: CampaignDailyCountsReport, expiry: Option[Long]) {
+    val mostRecentStats = report.pageCountStats.last
+
+    val totalUniques = mostRecentStats.getOrElse("cumulative-unique-total", 0L)
+    val targetToDate = mostRecentStats.getOrElse("cumulative-target-uniques", 0L)
+
+    AnalyticsDataCache.putCampaignSummary(campaignId, CampaignSummary(totalUniques, targetToDate), expiry)
   }
 
   private def cleanAndConvertRawDailyCounts(rawDailyCounts: ParsedDailyCountsReport, dailyUniqueTargetValue: Option[Long]): CampaignDailyCountsReport = {

--- a/conf/routes
+++ b/conf/routes
@@ -16,6 +16,7 @@ GET            /reauth            controllers.App.reauth
 #Campaign Api
 
 GET /api/campaigns                        controllers.CampaignApi.getAllCampaigns
+GET /api/campaigns/analytics              controllers.CampaignApi.getAnalyticsSummary
 GET /api/campaigns/:id                    controllers.CampaignApi.getCampaign(id: String)
 PUT /api/campaigns/:id                    controllers.CampaignApi.updateCampaign(id: String)
 DELETE /api/campaigns/:id                 controllers.CampaignApi.deleteCampaign(id: String)

--- a/public/components/Management/AnalyticsCache.js
+++ b/public/components/Management/AnalyticsCache.js
@@ -54,7 +54,7 @@ class AnalyticsCache extends Component {
   renderCacheItem = (item) => {
 
     return (
-      <div key={item.key + item.dateType} className="analytics-cache-list__item">
+      <div key={item.key + item.dataType} className="analytics-cache-list__item">
         <div className="analytics-cache-list__row">
           <div className="analytics-cache-list__key">
             <Link to={"/campaign/" + item.key}>{item.key}</Link>


### PR DESCRIPTION
Stores the headline campaign stats as a separate objects and as a rollup report for use when rendering campaign summaries.