### PR TITLE
compress analytics data when storing to dynamo

### DIFF
--- a/app/util/Compression.scala
+++ b/app/util/Compression.scala
@@ -1,0 +1,28 @@
+package util
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+import java.util.zip.{GZIPInputStream, GZIPOutputStream}
+
+import org.apache.commons.io.IOUtils
+
+
+object Compression {
+
+  def compress(data: String): Array[Byte] = {
+    val arrOutputStream = new ByteArrayOutputStream()
+    val zipOutputStream = new GZIPOutputStream(arrOutputStream)
+    zipOutputStream.write(data.getBytes)
+    zipOutputStream.close()
+    val bytes = (arrOutputStream.toByteArray)
+    arrOutputStream.close()
+    bytes
+  }
+
+  def decompress(compressed: Array[Byte]): String = {
+    val bis = new ByteArrayInputStream(compressed);
+    val gis = new GZIPInputStream(bis);
+    val bytes = IOUtils.toByteArray(gis);
+    return new String(bytes, "UTF-8");
+  }
+
+}

--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,7 @@ lazy val dependencies = Seq(
   "com.google.apis" % "google-api-services-analyticsreporting" % "v4-rev10-1.22.0",
   "com.squareup.okhttp3" % "okhttp" % "3.4.1",
   ws,
+  "commons-io" % "commons-io" % "2.5",
   "net.logstash.logback" % "logstash-logback-encoder" % "4.7",
   "com.gu" % "kinesis-logback-appender" % "1.3.0",
   "org.slf4j" % "slf4j-api" % slf4jVersion,


### PR DESCRIPTION
Once the paid content stuff was in the wild it turned out some analytics data was too big to fit in a dynamo entry (Aviva etc). This introduces gzip compression and stores the analytics as a binary blob.

On read the compressed data field is checked, if it exists then use this if not assume the entry is just storing a JSON string and use that.

for comparison here are the after and before records for explore Canada side by side in atom:

![screen shot 2016-11-07 at 17 25 39](https://cloud.githubusercontent.com/assets/145254/20068336/3a57a3e6-a510-11e6-9c73-51163dc2f4aa.png)

I couldn't reduce the font enough to fit all of the json on the screen - an improvement I'm sure you'll agree