### PR TITLE
show how a campaign is doing at a glance on the list view

### DIFF
--- a/public/actions/CampaignActions/getOverallAnalyticsSummary.js
+++ b/public/actions/CampaignActions/getOverallAnalyticsSummary.js
@@ -1,0 +1,37 @@
+import {fetchOverallAnalyticsSummary} from '../../services/CampaignsApi';
+
+function requestOverallAnalyticsSummary(id) {
+    return {
+        type:       'OVERALL_ANALYTICS_SUMMARY_GET_REQUEST',
+        id:         id,
+        receivedAt: Date.now()
+    };
+}
+
+function receiveOverallAnalyticsSummary(overallAnalyticsSummary) {
+    return {
+        type:        'OVERALL_ANALYTICS_SUMMARY_GET_RECEIVE',
+        overallAnalyticsSummary:    overallAnalyticsSummary,
+        receivedAt:  Date.now()
+    };
+}
+
+function errorRecievingOverallAnalyticsSummary(error) {
+    return {
+        type:       'SHOW_ERROR',
+        message:    'Could not get overall analytics summary',
+        error:      error,
+        receivedAt: Date.now()
+    };
+}
+
+export function getOverallAnalyticsSummary() {
+    return dispatch => {
+      dispatch(requestOverallAnalyticsSummary());
+      return fetchOverallAnalyticsSummary()
+        .catch(error => dispatch(errorRecievingOverallAnalyticsSummary(error)))
+        .then(res => {
+          dispatch(receiveOverallAnalyticsSummary(res));
+        });
+    };
+}

--- a/public/components/CampaignList/CampaignList.js
+++ b/public/components/CampaignList/CampaignList.js
@@ -9,7 +9,7 @@ class CampaignList extends React.Component {
 
   static defaultProps = {
     campaigns: []
-  }
+  };
 
   render () {
     if (!this.props.campaigns.length) {
@@ -30,10 +30,11 @@ class CampaignList extends React.Component {
             <th className="campaign-list__header">Value</th>
             <th className="campaign-list__header">Start date</th>
             <th className="campaign-list__header">Finish date</th>
+            <th className="campaign-list__header">Uniques</th>
           </tr>
         </thead>
           <tbody>
-            {this.props.campaigns.map((c) => <CampaignListItem campaign={c} key={c.id} />)}
+            {this.props.campaigns.map((c) => <CampaignListItem campaign={c} analyticsSummary={this.props.overallAnalyticsSummary[c.id]} key={c.id} />)}
           </tbody>
       </table>
     );

--- a/public/components/CampaignList/CampaignListItem.js
+++ b/public/components/CampaignList/CampaignListItem.js
@@ -15,6 +15,24 @@ class CampaignListItem extends React.Component {
     window.document.location = "/campaign/" + this.props.campaign.id;
   };
 
+  renderProgressSummary = () => {
+    var targetUniques = this.props.campaign.targets ? this.props.campaign.targets.uniques : '';
+
+    if (this.props.analyticsSummary) {
+      const progressClass = (this.props.analyticsSummary.totalUniques < this.props.analyticsSummary.targetToDate) ? 'campaign-list__item--behind' : 'campaign-list__item--ahead';
+
+      return(<td className={'campaign-list__item '+ progressClass}>
+        target: {targetUniques}<br />
+        progress: {this.props.analyticsSummary.totalUniques} uniques<br/>
+        against: {this.props.analyticsSummary.targetToDate} expected
+      </td>);
+    }
+
+    return(<td className="campaign-list__item">
+      target: {targetUniques}
+    </td>);
+  };
+
   render () {
 
     var image;
@@ -49,6 +67,7 @@ class CampaignListItem extends React.Component {
         <td className="campaign-list__item">{this.props.campaign.actualValue}</td>
         <td className="campaign-list__item">{startDate}</td>
         <td className="campaign-list__item">{endDate} {daysLeft}</td>
+        {this.renderProgressSummary()}
       </tr>
     );
   }

--- a/public/components/Campaigns/Campaigns.js
+++ b/public/components/Campaigns/Campaigns.js
@@ -6,7 +6,7 @@ class Campaigns extends Component {
   static propTypes = {
     campaigns: PropTypes.array.isRequired,
   }
-  
+
   filterCampaigns = (campaigns) => {
     var filtered = campaigns;
 
@@ -22,6 +22,7 @@ class Campaigns extends Component {
 
   componentDidMount() {
     this.props.campaignActions.getCampaigns();
+    this.props.analyticsActions.getOverallAnalyticsSummary();
   }
 
   render() {
@@ -29,7 +30,7 @@ class Campaigns extends Component {
     return (
       <div className="campaigns">
         <h2 className="campaigns__header">Campaigns</h2>
-        <CampaignList campaigns={this.filterCampaigns(this.props.campaigns)} />
+        <CampaignList campaigns={this.filterCampaigns(this.props.campaigns)} overallAnalyticsSummary={this.props.overallAnalyticsSummary} />
       </div>
     );
   }
@@ -39,10 +40,12 @@ class Campaigns extends Component {
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import * as getCampaigns from '../../actions/CampaignActions/getCampaigns';
+import * as getOverallAnalyticsSummary from '../../actions/CampaignActions/getOverallAnalyticsSummary';
 
 function mapStateToProps(state) {
   return {
     campaigns: state.campaigns,
+    overallAnalyticsSummary: state.overallAnalyticsSummary,
     campaignStateFilter: state.campaignStateFilter,
     campaignTypeFilter: state.campaignTypeFilter
   };
@@ -50,7 +53,8 @@ function mapStateToProps(state) {
 
 function mapDispatchToProps(dispatch) {
   return {
-    campaignActions: bindActionCreators(Object.assign({}, getCampaigns), dispatch)
+    campaignActions: bindActionCreators(Object.assign({}, getCampaigns), dispatch),
+    analyticsActions: bindActionCreators(Object.assign({}, getOverallAnalyticsSummary), dispatch)
   };
 }
 

--- a/public/reducers/overallAnalyticsSummaryReducer.js
+++ b/public/reducers/overallAnalyticsSummaryReducer.js
@@ -1,0 +1,11 @@
+
+export default function overallAnalyticsSummary(state = false, action) {
+  switch (action.type) {
+
+    case 'OVERALL_ANALYTICS_SUMMARY_GET_RECEIVE':
+      return action.overallAnalyticsSummary || false;
+
+    default:
+      return state;
+  }
+}

--- a/public/reducers/rootReducer.js
+++ b/public/reducers/rootReducer.js
@@ -13,6 +13,7 @@ import campaignTrafficDriverStats from './campaignTrafficDriverStatsReducer';
 import campaignNotes from './campaignNotesReducer';
 import campaignStateFilter from './campaignStateFilterReducer';
 import campaignTypeFilter from './campaignTypeFilterReducer';
+import overallAnalyticsSummary from './overallAnalyticsSummaryReducer';
 
 export default combineReducers({
   error,
@@ -28,5 +29,6 @@ export default combineReducers({
   campaignTrafficDriverStats,
   campaignNotes,
   campaignStateFilter,
-  campaignTypeFilter
+  campaignTypeFilter,
+  overallAnalyticsSummary
 });

--- a/public/services/CampaignsApi.js
+++ b/public/services/CampaignsApi.js
@@ -33,6 +33,14 @@ export function deleteCampaign(id) {
   });
 }
 
+export function fetchOverallAnalyticsSummary() {
+  return AuthedReqwest({
+    url: '/api/campaigns/analytics',
+    contentType: 'application/json',
+    method: 'get'
+  });
+}
+
 export function fetchCampaignAnalytics(id) {
   return AuthedReqwest({
     url: '/api/campaigns/' + id + '/analytics',

--- a/public/styles/components/campaigns-list/_campaigns-list.scss
+++ b/public/styles/components/campaigns-list/_campaigns-list.scss
@@ -45,7 +45,17 @@
   border-top: 1px solid $c-grey-400;
   border-right: 1px solid $c-grey-400;
 
+  font-size: 14px;
+
   color: $c-grey-main;
+}
+
+.campaign-list__item--ahead {
+  color: $c-green;
+}
+
+.campaign-list__item--behind {
+  color: $c-red;
 }
 
 .campaign-list__item:last-child {


### PR DESCRIPTION
Used the analytics summary to display how a campaign is doing against where it should be and provides traffic light style colouring.

<img width="1008" alt="screen shot 2016-11-11 at 16 29 14" src="https://cloud.githubusercontent.com/assets/145254/20222146/12a461e4-a82c-11e6-8023-a6e2f5fb4e32.png">

Hopefully it's clear. i plan to roll this out and then gather feedback on wording etc once it's in front of people.
