### PR TITLE
Show spinner while waiting for traffic driver data to load

### DIFF
--- a/public/components/CampaignAnalytics/Analytics/CampaignTrafficDriverStatsChart.js
+++ b/public/components/CampaignAnalytics/Analytics/CampaignTrafficDriverStatsChart.js
@@ -1,4 +1,5 @@
 import React, {PropTypes} from "react";
+import ProgressSpinner from "../../utils/ProgressSpinner";
 import {
   LineChart,
   Line,
@@ -63,7 +64,7 @@ class CampaignTrafficDriverStatsChart extends React.Component {
           <a name={anchorName}/>
           <div className="campaign-box__header">{group.groupName}</div>
           <div className="campaign-box__body">
-            <span className="campaign-assets__field__value">No data yet.</span>
+            <span className="campaign-assets__field__value">No traffic driver data available.</span>
           </div>
         </div>
       );
@@ -113,36 +114,34 @@ class CampaignTrafficDriverStatsChart extends React.Component {
     );
   };
 
-  render() {
+  renderGroupCharts() {
 
     if (!this.props.campaignTrafficDriverStats) {
       return (
-        <div className="analytics-chart--full-width">
-          <div className="campaign-box__header">Traffic Driver Performance
-            <span className="campaign-driver-list__link"><a href="#driver-summary">Back to summary</a></span>
-          </div>
-          <ProgressSpinner />
-        </div>
+        <ProgressSpinner />
       );
     }
 
     if (this.props.campaignTrafficDriverStats.length > 0) {
       return (
-        <div className="analytics-chart--full-width">
-          <div className="campaign-box__header">Traffic Driver Performance
-            <span className="campaign-driver-list__link"><a href="#driver-summary">Back to summary</a></span>
-          </div>
+        <div>
           {this.props.campaignTrafficDriverStats.map(this.renderDriverGroupChart)}
         </div>
       );
     }
 
     return (
+      <span className="campaign-assets__field__value">No traffic driver data available.</span>
+    );
+  }
+
+  render() {
+    return (
       <div className="analytics-chart--full-width">
         <div className="campaign-box__header">Traffic Driver Performance
           <span className="campaign-driver-list__link"><a href="#driver-summary">Back to summary</a></span>
         </div>
-        <span className="campaign-assets__field__value">No traffic driver data to show.</span>
+        {this.renderGroupCharts()}
       </div>
     );
   }

--- a/public/reducers/campaignTrafficDriverReducer.js
+++ b/public/reducers/campaignTrafficDriverReducer.js
@@ -1,4 +1,4 @@
-export default function campaignTrafficDrivers(state = [], action) {
+export default function campaignTrafficDrivers(state = null, action) {
   switch (action.type) {
 
     case 'TRAFFIC_DRIVERS_GET_RECEIVE':

--- a/public/reducers/campaignTrafficDriverStatsReducer.js
+++ b/public/reducers/campaignTrafficDriverStatsReducer.js
@@ -1,4 +1,4 @@
-export default function campaignTrafficDriverStats(state = [], action) {
+export default function campaignTrafficDriverStats(state = null, action) {
   switch (action.type) {
 
     case 'TRAFFIC_DRIVER_STATS_GET_RECEIVE':


### PR DESCRIPTION
So that you know you're waiting for a result, rather than there being no data available.

This also removes some repeated code in the traffic driver stats template.