### PR TITLE
Look up DFP line items in multiple orders

### DIFF
--- a/app/model/TrafficDriver.scala
+++ b/app/model/TrafficDriver.scala
@@ -101,14 +101,14 @@ object TrafficDriverGroup {
   def forCampaign(campaignId: String): Seq[TrafficDriverGroup] = {
     val dfpSession = DfpFetcher.mkSession()
 
-    def trafficDrivers(orderId: Long): Seq[TrafficDriver] =
-      DfpFetcher.fetchLineItemsByOrder(dfpSession, orderId) filter {
+    def trafficDrivers(orderIds: Set[Long]): Seq[TrafficDriver] =
+      DfpFetcher.fetchLineItemsByOrder(dfpSession, orderIds) filter {
         DfpFilter.hasCampaignIdCustomFieldValue(campaignId)
       } map TrafficDriver.fromDfpLineItem
 
     Seq(
-      TrafficDriverGroup.fromTrafficDrivers("Native cards", trafficDrivers(dfpNativeCardOrderId)),
-      TrafficDriverGroup.fromTrafficDrivers("Merchandising", trafficDrivers(dfpMerchandisingOrderId))
+      TrafficDriverGroup.fromTrafficDrivers("Native cards", trafficDrivers(dfpNativeCardOrderIds)),
+      TrafficDriverGroup.fromTrafficDrivers("Merchandising", trafficDrivers(dfpMerchandisingOrderIds))
     ).flatten
   }
 }
@@ -159,9 +159,9 @@ object TrafficDriverGroupStats {
 
     val dfpSession = DfpFetcher.mkSession()
 
-    def fetchStats(groupName: String, orderId: Long): TrafficDriverGroupStats = {
+    def fetchStats(groupName: String, orderIds: Set[Long]): TrafficDriverGroupStats = {
 
-      val lineItemIds = DfpFetcher.fetchLineItemsByOrder(dfpSession, orderId) filter {
+      val lineItemIds = DfpFetcher.fetchLineItemsByOrder(dfpSession, orderIds) filter {
         DfpFilter.hasCampaignIdCustomFieldValue(campaignId)
       } map (_.getId.toLong)
 
@@ -172,8 +172,8 @@ object TrafficDriverGroupStats {
     }
 
     val stats = Seq(
-      ("Native cards", dfpNativeCardOrderId),
-      ("Merchandising", dfpMerchandisingOrderId)
+      ("Native cards", dfpNativeCardOrderIds),
+      ("Merchandising", dfpMerchandisingOrderIds)
     ).par.map { case (groupName, orderId) =>
       fetchStats(groupName, orderId)
     }.toList

--- a/app/services/Config.scala
+++ b/app/services/Config.scala
@@ -67,8 +67,8 @@ sealed trait Config {
   lazy val dfpClientSecret = getRequiredRemoteStringProperty("dfp.client.secret")
   lazy val dfpRefreshToken = getRequiredRemoteStringProperty("dfp.refresh.token")
   def dfpNetworkCode: String
-  def dfpNativeCardOrderId: Long
-  def dfpMerchandisingOrderId: Long
+  def dfpNativeCardOrderIds: Set[Long]
+  def dfpMerchandisingOrderIds: Set[Long]
   def dfpCampaignFieldId: Long
 
   def googleServiceAccountJsonInputStream: InputStream = {
@@ -120,8 +120,8 @@ class DevConfig extends Config {
   override def ctaAtomMakerUrl = "https://cta-atom-maker.local.dev-gutools.co.uk"
 
   override val dfpNetworkCode = "158186692"
-  override val dfpNativeCardOrderId: Long = 550773372
-  override val dfpMerchandisingOrderId: Long = 550774092
+  override val dfpNativeCardOrderIds = Set(550773372L)
+  override val dfpMerchandisingOrderIds = Set(550774092L)
   override val dfpCampaignFieldId: Long = 26412
 }
 
@@ -141,8 +141,8 @@ class CodeConfig extends Config {
   override def ctaAtomMakerUrl = "https://cta-atom-maker.code.dev-gutools.co.uk"
 
   override val dfpNetworkCode = "158186692"
-  override val dfpNativeCardOrderId: Long = 550773372
-  override val dfpMerchandisingOrderId: Long = 550774092
+  override val dfpNativeCardOrderIds = Set(550773372L)
+  override val dfpMerchandisingOrderIds = Set(550774092L)
   override val dfpCampaignFieldId: Long = 26412
 }
 
@@ -162,7 +162,15 @@ class ProdConfig extends Config {
   override def ctaAtomMakerUrl = "https://cta-atom-maker.gutools.co.uk"
 
   override val dfpNetworkCode = "59666047"
-  override val dfpNativeCardOrderId: Long = 353494647
-  override val dfpMerchandisingOrderId: Long = 345535767
+  override val dfpNativeCardOrderIds = {
+    val hostedOrder: Long = 353494647
+    val paidOrder: Long = 347621127
+    Set(hostedOrder, paidOrder)
+  }
+  override val dfpMerchandisingOrderIds = {
+    val hostedOrder: Long = 345535767
+    val paidOrder: Long = 211298847
+    Set(hostedOrder, paidOrder)
+  }
   override val dfpCampaignFieldId: Long = 9927
 }

--- a/app/services/Dfp.scala
+++ b/app/services/Dfp.scala
@@ -35,22 +35,21 @@ object DfpFetcher {
     .build()
   }
 
-  def fetchLineItemsByOrder(session: DfpSession, orderId: Long): Seq[LineItem] = {
+  def fetchLineItemsByOrder(session: DfpSession, orderIds: Set[Long]): Seq[LineItem] = {
 
     val start = System.currentTimeMillis
     val lineItems = fetchLineItems(
       session,
       new StatementBuilder()
-      .where("orderId = :orderId")
-      .withBindVariableValue("orderId", orderId)
+      .where(s"orderId in (${orderIds.mkString(",")})")
       .toStatement
     )
 
     lineItems match {
       case Failure(e) =>
-        Logger.error(s"Fetching line items for order $orderId failed: ${e.getMessage}")
+        Logger.error(s"Fetching line items for orders $orderIds failed: ${e.getMessage}")
       case Success(items) =>
-        Logger.info(s"Fetched ${items.size} line items for order $orderId in ${System.currentTimeMillis - start} ms")
+        Logger.info(s"Fetched ${items.size} line items for orders $orderIds in ${System.currentTimeMillis - start} ms")
     }
 
     lineItems getOrElse Nil


### PR DESCRIPTION
There are separate orders for hosted and paid traffic drivers.  That's why the expected traffic drivers weren't appearing in paid campaigns.