### PR TITLE
Possibly improve measurement of campaign 'uniques'

### DIFF
--- a/app/controllers/CampaignApi.scala
+++ b/app/controllers/CampaignApi.scala
@@ -1,7 +1,5 @@
 package controllers
 
-import java.util.UUID
-
 import model._
 import model.command.CommandError._
 import model.command.{ImportCampaignFromCAPICommand, RefreshCampaignFromCAPICommand}
@@ -45,7 +43,7 @@ class CampaignApi(override val wsClient: WSClient) extends Controller with Panda
   }
 
   def getCampaignAnalytics(id: String) = APIAuthAction { req =>
-    GoogleAnalytics.getAnalyticsForCampaign(id).map { c => Ok(Json.toJson(c)) } getOrElse NotFound
+    Analytics.getAnalyticsForCampaign(id).map { c => Ok(Json.toJson(c)) } getOrElse NotFound
   }
 
   def getCampaignContent(id: String) =  APIAuthAction { req =>
@@ -143,6 +141,6 @@ class CampaignApi(override val wsClient: WSClient) extends Controller with Panda
   }
 
   def getCampaignCtaStats(campaignId: String) = APIAuthAction { req =>
-    Ok(toJson(GoogleAnalytics.getCtaClicksForCampaign(campaignId)))
+    Ok(toJson(Analytics.getCtaClicksForCampaign(campaignId)))
   }
 }

--- a/app/controllers/ManagementApi.scala
+++ b/app/controllers/ManagementApi.scala
@@ -7,7 +7,7 @@ import play.api.Logger
 import play.api.libs.json._
 import play.api.libs.ws.WSClient
 import play.api.mvc.Controller
-import repositories.{AnalyticsDataCache, GoogleAnalytics}
+import repositories.{Analytics, AnalyticsDataCache}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -33,7 +33,7 @@ class ManagementApi(override val wsClient: WSClient) extends Controller with Pan
 
   def refreshAnalyticsCacheForType(dataType: String) = APIAuthAction { req =>
     AnalyticsDataCache.summariseContents.filter{ e =>
-      val expired = e.expires.map(_ < System.currentTimeMillis).getOrElse(false)
+      val expired = e.expires.exists(_ < System.currentTimeMillis)
       e.dataType == dataType && expired
     }.foreach{ e =>
       refreshEntry(e.dataType, e.key)
@@ -46,11 +46,11 @@ class ManagementApi(override val wsClient: WSClient) extends Controller with Pan
     dataType match {
       case "CampaignDailyCountsReport" => {
         Logger.info(s"manually clearing GA analytics for $key")
-        Future {GoogleAnalytics.getAnalyticsForCampaign(key)}
+        Future {Analytics.getAnalyticsForCampaign(key)}
       }
       case "CtaClicksReport" => {
         Logger.info(s"manually clearing GA CTA CTR analytics for $key")
-        Future {GoogleAnalytics.getCtaClicksForCampaign(key)}
+        Future {Analytics.getCtaClicksForCampaign(key)}
       }
       case "TrafficDriverGroupStats" => {
         Logger.info(s"manually clearing Traffic driver stats for $key")

--- a/app/model/analyticsReports.scala
+++ b/app/model/analyticsReports.scala
@@ -2,7 +2,7 @@ package model
 
 import ai.x.play.json.Jsonx
 import play.api.libs.json.Format
-import repositories.GoogleAnalytics.ParsedDailyCountsReport
+import repositories.Analytics.ParsedDailyCountsReport
 
 case class CampaignDailyCountsReport(seenPaths: Set[String], pageCountStats: List[Map[String, Long]])
 
@@ -25,4 +25,3 @@ case class CampaignSummary(totalUniques: Long, targetToDate: Long)
 object CampaignSummary{
   implicit val campaignSummaryFormat: Format[CampaignSummary] = Jsonx.formatCaseClass[CampaignSummary]
 }
-

--- a/app/repositories/Analytics.scala
+++ b/app/repositories/Analytics.scala
@@ -70,7 +70,7 @@ object Analytics {
         campaign <- CampaignRepository.getCampaign(campaignId)
         sectionId <- campaign.pathPrefix
       } yield {
-        GoogleAnalytics.loadSectionUniqueVisitorCount(sectionId, campaign.startDate, campaign.endDate)
+        GoogleAnalytics.loadSectionUniquePageViewCount(sectionId, campaign.startDate, campaign.endDate)
       }
       uniques getOrElse 0L
     }

--- a/app/services/GoogleAnalytics.scala
+++ b/app/services/GoogleAnalytics.scala
@@ -81,8 +81,8 @@ object GoogleAnalytics {
     clickCount.getOrElse(0L)
   }
 
-  def loadSectionUniqueVisitorCount(sectionId: String, startDate: Option[DateTime], endDate: Option[DateTime]): Long = {
-    Logger.info(s"fetch unique visitor count for section '$sectionId'")
+  def loadSectionUniquePageViewCount(sectionId: String, startDate: Option[DateTime], endDate: Option[DateTime]): Long = {
+    Logger.info(s"fetch unique page view count for section '$sectionId'")
 
     val dateRange = new DateRange().setStartDate(startOfRange(startDate)).setEndDate(endOfRange(endDate))
 
@@ -90,7 +90,7 @@ object GoogleAnalytics {
                              .setViewId(Config().googleAnalyticsViewId)
                              .setDateRanges(Seq(dateRange))
                              .setMetrics(Seq(new Metric().setExpression("ga:users").setAlias("users")))
-                             .setFiltersExpression(s"ga:dimension4==$sectionId")
+                             .setFiltersExpression(s"ga:pagepath=~/$sectionId")
                              .setSamplingLevel("LARGE")
                              .setIncludeEmptyRows(true)
 

--- a/app/services/GoogleAnalytics.scala
+++ b/app/services/GoogleAnalytics.scala
@@ -26,13 +26,13 @@ object GoogleAnalytics {
     } getOrElse "yesterday"
   }
 
+  private val pageViewMetric = new Metric().setExpression("ga:pageviews").setAlias("pageviews")
+  private val uniqueViewMetric = new Metric().setExpression("ga:uniquePageviews").setAlias("uniques")
+
   def loadDailyCounts(gaFilter: String, startDate: DateTime, endDate: Option[DateTime]): GetReportsResponse = {
     Logger.info(s"fetch ga analytics with filter $gaFilter")
 
     val dateRange = new DateRange().setStartDate(startDate.toString(datePattern)).setEndDate(endOfRange(endDate))
-
-    val pageViewMetric = new Metric().setExpression("ga:pageviews").setAlias("pageviews")
-    val uniqueViewMetric = new Metric().setExpression("ga:uniquePageviews").setAlias("uniques")
 
     val dateDimension = new Dimension().setName("ga:date")
     val pathDimension = new Dimension().setName("ga:pagePath")
@@ -89,7 +89,7 @@ object GoogleAnalytics {
     val viewsReportRequest = new ReportRequest()
                              .setViewId(Config().googleAnalyticsViewId)
                              .setDateRanges(Seq(dateRange))
-                             .setMetrics(Seq(new Metric().setExpression("ga:users").setAlias("users")))
+                             .setMetrics(Seq(uniqueViewMetric))
                              .setFiltersExpression(s"ga:pagepath=~/$sectionId")
                              .setSamplingLevel("LARGE")
                              .setIncludeEmptyRows(true)

--- a/app/services/GoogleAnalytics.scala
+++ b/app/services/GoogleAnalytics.scala
@@ -1,0 +1,136 @@
+package services
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
+import com.google.api.client.http.{HttpRequest, HttpRequestInitializer}
+import com.google.api.services.analyticsreporting.v4.model._
+import com.google.api.services.analyticsreporting.v4.{AnalyticsReporting, AnalyticsReportingScopes}
+import org.joda.time.DateTime
+import play.api.Logger
+
+import scala.collection.JavaConversions._
+
+object GoogleAnalytics {
+
+  private val gaClient = initialiseGaClient
+
+  private val datePattern = "yyyy-MM-dd"
+
+  private def startOfRange(startDate: Option[DateTime]): String = {
+    startDate.getOrElse(new DateTime().minusMonths(1)).toString(datePattern)
+  }
+
+  private def endOfRange(endDate: Option[DateTime]): String = {
+    endDate.flatMap { date =>
+      if (date.isBeforeNow) Some(date.toString(datePattern)) else None
+    } getOrElse "yesterday"
+  }
+
+  def loadDailyCounts(gaFilter: String, startDate: DateTime, endDate: Option[DateTime]): GetReportsResponse = {
+    Logger.info(s"fetch ga analytics with filter $gaFilter")
+
+    val dateRange = new DateRange().setStartDate(startDate.toString(datePattern)).setEndDate(endOfRange(endDate))
+
+    val pageViewMetric = new Metric().setExpression("ga:pageviews").setAlias("pageviews")
+    val uniqueViewMetric = new Metric().setExpression("ga:uniquePageviews").setAlias("uniques")
+
+    val dateDimension = new Dimension().setName("ga:date")
+    val pathDimension = new Dimension().setName("ga:pagePath")
+
+    val viewsReportRequest = new ReportRequest()
+      .setDateRanges(List(dateRange))
+      .setMetrics(List(pageViewMetric, uniqueViewMetric))
+      .setDimensions(List(dateDimension, pathDimension))
+      .setFiltersExpression(gaFilter)
+      .setIncludeEmptyRows(true)
+      .setSamplingLevel("LARGE")
+      .setViewId(Config().googleAnalyticsViewId)
+
+    val getReportsRequest = new GetReportsRequest().setReportRequests(List(viewsReportRequest))
+
+    gaClient.reports().batchGet(getReportsRequest).execute()
+  }
+
+  def loadCtaClicks(trackingCode: String, startDate: DateTime, endDate: Option[DateTime]): Long = {
+    Logger.info(s"fetch CTa clicks for cta $trackingCode")
+
+    val dateRange = new DateRange().setStartDate(startDate.toString(datePattern)).setEndDate(endOfRange(endDate))
+
+    val totalEvents = new Metric().setExpression("ga:totalEvents").setAlias("totalEvents")
+
+    val viewsReportRequest = new ReportRequest()
+      .setDateRanges(List(dateRange))
+      .setMetrics(List(totalEvents))
+      .setFiltersExpression(s"ga:eventCategory==Click;ga:eventAction==External;ga:eventLabel==$trackingCode")
+      .setIncludeEmptyRows(true)
+      .setSamplingLevel("LARGE")
+      .setViewId(Config().googleAnalyticsViewId)
+
+    val getReportsRequest = new GetReportsRequest().setReportRequests(List(viewsReportRequest))
+
+    val reportResponse = gaClient.reports().batchGet(getReportsRequest).execute()
+
+    // this report has a single value, so just dive in grabbing the first entry at each level
+    val clickCount = for(
+      report <- reportResponse.getReports.headOption;
+      row <- report.getData.getRows.headOption;
+      metrics <- row.getMetrics.headOption;
+      value <- metrics.getValues.headOption
+    ) yield { value.toLong}
+
+    clickCount.getOrElse(0L)
+  }
+
+  def loadSectionUniqueVisitorCount(sectionId: String, startDate: Option[DateTime], endDate: Option[DateTime]): Long = {
+    Logger.info(s"fetch unique visitor count for section '$sectionId'")
+
+    val dateRange = new DateRange().setStartDate(startOfRange(startDate)).setEndDate(endOfRange(endDate))
+
+    val viewsReportRequest = new ReportRequest()
+                             .setViewId(Config().googleAnalyticsViewId)
+                             .setDateRanges(Seq(dateRange))
+                             .setMetrics(Seq(new Metric().setExpression("ga:users").setAlias("users")))
+                             .setFiltersExpression(s"ga:dimension4==$sectionId")
+                             .setSamplingLevel("LARGE")
+                             .setIncludeEmptyRows(true)
+
+    val getReportsRequest = new GetReportsRequest().setReportRequests(Seq(viewsReportRequest))
+
+    val reportResponse = GoogleAnalytics.gaClient.reports().batchGet(getReportsRequest).execute()
+
+    val count = for (
+      report <- reportResponse.getReports.headOption;
+      row <- report.getData.getRows.headOption;
+      metrics <- row.getMetrics.headOption;
+      value <- metrics.getValues.headOption
+    ) yield {
+      value.toLong
+    }
+
+    count getOrElse 0
+  }
+
+  // general GA connection stuff
+
+  private def initialiseGaClient = {
+
+    val httpTransport = GoogleNetHttpTransport.newTrustedTransport()
+    val credential = GoogleCredential.fromStream(Config().googleServiceAccountJsonInputStream)
+    val scoped = credential.createScoped(List(AnalyticsReportingScopes.ANALYTICS_READONLY))
+
+    new AnalyticsReporting.Builder(
+        httpTransport,
+        com.google.api.client.googleapis.util.Utils.getDefaultJsonFactory,
+        new TimeoutRequestInitializer(scoped))
+      .setApplicationName("campaign central")
+      .build()
+  }
+
+  private class TimeoutRequestInitializer(creds: HttpRequestInitializer) extends HttpRequestInitializer {
+    override def initialize(request: HttpRequest): Unit = {
+      creds.initialize(request)
+      request.setConnectTimeout(3 * 60000) // 3 minutes connect timeout
+      request.setReadTimeout(3 * 60000)
+    }
+  }
+}


### PR DESCRIPTION
This change measures unique page views per campaign directly from GA, instead of deriving the figure from unique page views per campaign page.
This value shouldn't be sampled, so should be accurate.
But it might not be what people expect!

Although assuming happiness ≈ accuracy / expectation * randomFactor.

There's some refactoring too.

/cc @steppenwells @guardian/labs-beta 