### PR TITLE
Sw refresh bug fixes

### DIFF
--- a/app/model/command/ImportCampaignFromCAPICommand.scala
+++ b/app/model/command/ImportCampaignFromCAPICommand.scala
@@ -31,8 +31,8 @@ trait CAPIImportCommand extends Command {
     apiContent.tags.filter(_.`type` == TagType.Type).headOption.map(_.webTitle).getOrElse(UnableToDetermineContentType)
   }
 
-  def deriveTagLogo(tag: Tag): Option[String] = {
-    tag.activeSponsorships.flatMap(_.headOption.map(_.sponsorLogo))
+  def deriveSponsorshipLogo(sponsorship: Option[Sponsorship]): Option[String] = {
+    sponsorship.flatMap(_.sponsorLogo.assets.headOption.map(_.imageUrl))
   }
 
   def buildAtomList(apiContent: ApiContent): List[Atom] = {
@@ -83,7 +83,7 @@ trait CAPIImportCommand extends Command {
         ctaAtom.cta.trackingCode
         CallToAction(Some(atomData.id), ctaAtom.cta.trackingCode)
       }.distinct,
-      campaignLogo = deriveTagLogo(hostedTag)
+      campaignLogo = deriveSponsorshipLogo(sponsorship) orElse campaign.campaignLogo
     )
 
     CampaignRepository.putCampaign(updatedCampaign)

--- a/public/components/CampaignList/CampaignListItem.js
+++ b/public/components/CampaignList/CampaignListItem.js
@@ -55,8 +55,16 @@ class CampaignListItem extends React.Component {
       const now = new Date();
       const oneDayMillis = 24 * 60 * 60 * 1000;
       const days = Math.round((this.props.campaign.endDate - now) / oneDayMillis);
+      var dayWord = ' days';
+      if(Math.abs(days) === 1) {
+        dayWord = ' day'
+      }
 
-      daysLeft = ' - ' + days + ' days left';
+      if (days < 0) {
+        daysLeft = ' - ended ' + (days * -1) + dayWord + ' ago';
+      } else {
+        daysLeft = ' - ' + days + dayWord + ' left';
+      }
     }
 
     return (

--- a/public/components/CapiImport/CapiImport.js
+++ b/public/components/CapiImport/CapiImport.js
@@ -35,8 +35,8 @@ class CapiImport extends Component {
 
     return (
       <div className="campaigns">
-        <h2 className="campaigns__header">Capi importer</h2>
-        <p>Select a hosted content campaign tag and we'll import it as a campaign.</p>
+        <h2 className="campaigns__header">Campaign importer</h2>
+        <p>Select a campaign tag (hosted or paid content) and we'll import it as a campaign.</p>
         <TagPicker type="paidContent" onTagSelected={this.tagSelected}/>
         {this.renderThobber()}
       </div>

--- a/public/components/Sidebar/Sidebar.js
+++ b/public/components/Sidebar/Sidebar.js
@@ -62,7 +62,7 @@ class Sidebar extends React.Component {
         </div>
         <div className="sidebar__link-group">
           <div className="sidebar__link-group__header">Tools</div>
-          <SidebarLink to="/capiImport">Import from CAPI</SidebarLink>
+          <SidebarLink to="/capiImport">Import campaign</SidebarLink>
         </div>
       </div>
     );


### PR DESCRIPTION
Fed up with not making progress on unique users I've fix a few bugs that I found in trello. They are:

- after refresh ended campaigns become live again
- after refresh ended campaigns loose their logo
- rename capi import to import campaign

And as a bonus stop saying ended campaigns end in -x days, not say they ended x days ago (and depluralise "days" when there's only one day in question).

