### PR TITLE
Campaigns' columns sorting fixes

### DIFF
--- a/public/components/CampaignList/CampaignList.js
+++ b/public/components/CampaignList/CampaignList.js
@@ -27,7 +27,7 @@ class CampaignList extends React.Component {
   };
 
   setHeaderCssClass = (column) => {
-    let sortedColumn = this.props.campaignSortColumn || 'name';
+    let sortedColumn = this.props.campaignSortColumn || 'endDate';
     let order = this.getSortOrder(column) ? 'asc' : 'desc';
     let newCssClass = 'campaign-list__header-order';
 

--- a/public/components/Campaigns/Campaigns.js
+++ b/public/components/Campaigns/Campaigns.js
@@ -59,7 +59,7 @@ class Campaigns extends Component {
 
   sortCampaigns = (campaigns) => {
     let sorted = campaigns;
-    let column = this.props.campaignSortColumn || 'endDate';
+    let column = this.props.campaignSortColumn;
     let order = this.props.campaignSortOrder || false;
 
     sorted = sorted.sort(this.sortBy(column, order, function(value) {

--- a/public/components/Campaigns/Campaigns.js
+++ b/public/components/Campaigns/Campaigns.js
@@ -42,11 +42,14 @@ class Campaigns extends Component {
         break;
       case 'actualValue':
       case 'startDate':
-      case 'endDate':
         if (typeof value === 'undefined') {
           value = 0;
         }
         value = parseInt(value, 10);
+      case 'endDate':
+        if (typeof value === 'undefined') {
+          value = Infinity;
+        }
       default:
         value;
     }
@@ -56,7 +59,7 @@ class Campaigns extends Component {
 
   sortCampaigns = (campaigns) => {
     let sorted = campaigns;
-    let column = this.props.campaignSortColumn || 'name';
+    let column = this.props.campaignSortColumn || 'endDate';
     let order = this.props.campaignSortOrder || false;
 
     sorted = sorted.sort(this.sortBy(column, order, function(value) {

--- a/public/styles/components/campaigns-list/_campaigns-list.scss
+++ b/public/styles/components/campaigns-list/_campaigns-list.scss
@@ -119,6 +119,7 @@
 }
 
 .campaign-list__header--sortable.actualValue {
+  min-width: 80px;
   [class^='campaign-list__header-order'] {
     &::after,
     &::before {
@@ -128,6 +129,7 @@
 }
 
 .campaign-list__header--sortable.startDate {
+  min-width: 114px;
   [class^='campaign-list__header-order'] {
     &::after,
     &::before {


### PR DESCRIPTION
The campaign's list by default should be sorted by the end date field. All 'not yet configured values' should be infinite so by default (DESC order) they will be at the bottom of the list.

I also fixed the `min-width` value of columns so they will be correctly visible on smaller breakpoints.

Before:
<img width="1032" alt="screen shot 2016-12-05 at 15 01 43" src="https://cloud.githubusercontent.com/assets/489567/20891625/341a8b70-bb03-11e6-98ed-da632b0e3318.png">


After:
<img width="1028" alt="screen shot 2016-12-05 at 15 01 13" src="https://cloud.githubusercontent.com/assets/489567/20891606/2cfc20c4-bb03-11e6-816d-bed33b220220.png">
