### PR TITLE
Link DFP line items to campaigns

### DIFF
--- a/app/controllers/CampaignApi.scala
+++ b/app/controllers/CampaignApi.scala
@@ -1,7 +1,5 @@
 package controllers
 
-import java.util.UUID
-
 import model._
 import model.command.CommandError._
 import model.command.{ImportCampaignFromCAPICommand, RefreshCampaignFromCAPICommand}
@@ -140,6 +138,12 @@ class CampaignApi(override val wsClient: WSClient) extends Controller with Panda
   def getSuggestedCampaignTrafficDrivers(campaignId: String) = APIAuthAction { req =>
     Logger.info(s"Loading suggested traffic drivers for campaign $campaignId")
     Ok(toJson(LineItemSummary.suggestedTrafficDriversForCampaign(campaignId)))
+  }
+
+  def acceptSuggestedCampaignTrafficDriver(campaignId: String, lineItemId: Long) = APIAuthAction { req =>
+    Logger.info(s"Accepting traffic driver $lineItemId for campaign $campaignId")
+    LineItemSummary.acceptSuggestedTrafficDriver(campaignId, lineItemId)
+    NoContent
   }
 
   def getCampaignTrafficDriverStats(campaignId: String) = APIAuthAction { req =>

--- a/app/model/TrafficDriver.scala
+++ b/app/model/TrafficDriver.scala
@@ -104,9 +104,9 @@ object TrafficDriverGroup {
       nativeCardOrderId <- dfpNativeCardOrderIds.get(campaign.`type`)
       merchandisingOrderId <- dfpMerchandisingOrderIds.get(campaign.`type`)
     } yield {
-      val dfpSession = Dfp.mkSession()
+      val lineItemService = Dfp.mkLineItemService(Dfp.mkSession())
       def trafficDrivers(orderIds: Seq[Long]): Seq[TrafficDriver] =
-        Dfp.fetchLineItemsByOrder(dfpSession, orderIds) filter {
+        Dfp.fetchLineItemsByOrder(lineItemService, orderIds) filter {
           Dfp.hasCampaignIdCustomFieldValue(campaignId)
         } map TrafficDriver.fromDfpLineItem
       Seq(
@@ -167,13 +167,15 @@ object TrafficDriverGroupStats {
       merchandisingOrderIds <- dfpMerchandisingOrderIds.get(campaign.`type`)
     } yield {
       val dfpSession = Dfp.mkSession()
+      val dfpLineItemService = Dfp.mkLineItemService(dfpSession)
+      val dfpReportService = Dfp.mkReportService(dfpSession)
       def fetchStats(groupName: String, orderIds: Seq[Long]): TrafficDriverGroupStats = {
-        val lineItemIds = Dfp.fetchLineItemsByOrder(dfpSession, orderIds) filter {
+        val lineItemIds = Dfp.fetchLineItemsByOrder(dfpLineItemService, orderIds) filter {
           Dfp.hasCampaignIdCustomFieldValue(campaignId)
         } map (_.getId.toLong)
         TrafficDriverGroupStats(
           groupName,
-          Dfp.fetchStatsReport(dfpSession, lineItemIds).map(DayStats.fromDfpReport) getOrElse Nil
+          Dfp.fetchStatsReport(dfpReportService, lineItemIds).map(DayStats.fromDfpReport) getOrElse Nil
         )
       }
       val fetched = Seq(
@@ -207,8 +209,9 @@ object LineItemSummary {
       nativeCardOrderIds <- dfpNativeCardOrderIds.get(campaign.`type`)
       merchandisingCardOrderIds <- dfpMerchandisingOrderIds.get(campaign.`type`)
     } yield {
+      val dfpLineItemService = Dfp.mkLineItemService(Dfp.mkSession())
       def fetch(orderIds: Seq[Long]) =
-        Dfp.fetchSuggestedLineItems(campaign.name, client.name, Dfp.mkSession(), orderIds) map {
+        Dfp.fetchSuggestedLineItems(campaign.name, client.name, dfpLineItemService, orderIds) map {
           LineItemSummary.fromLineItem
       }
       Map(
@@ -217,5 +220,9 @@ object LineItemSummary {
       )
     }
     lineItems getOrElse Map.empty
+  }
+
+  def acceptSuggestedTrafficDriver(campaignId: String, lineItemId: Long): Unit = {
+    Dfp.linkLineItemToCampaign(Dfp.mkLineItemService(Dfp.mkSession()), lineItemId, campaignId)
   }
 }

--- a/app/services/Dfp.scala
+++ b/app/services/Dfp.scala
@@ -16,49 +16,38 @@ import services.Config.conf._
 import scala.io.{BufferedSource, Source}
 import scala.util.{Failure, Success, Try}
 
-object Dfp {
+object Dfp extends DfpService {
 
-  System.setProperty("api.dfp.soapRequestTimeout", "300000")
-
-  def mkSession(): DfpSession = {
-    new DfpSession.Builder()
-    .withOAuth2Credential(
-      new OfflineCredentials.Builder()
-      .forApi(DFP)
-      .withClientSecrets(dfpClientId, dfpClientSecret)
-      .withRefreshToken(dfpRefreshToken)
-      .build()
-      .generateCredential()
-    )
-    .withApplicationName(dfpAppName)
-    .withNetworkCode(dfpNetworkCode)
-    .build()
+  def fetchLineItemById(service: LineItemServiceInterface, id: Long): Option[LineItem] = {
+    fetchLineItems(
+      service,
+      new StatementBuilder().where("id = :id").withBindVariableValue("id", id).toStatement
+    ).headOption
   }
 
-  def fetchLineItemsByOrder(session: DfpSession, orderIds: Seq[Long]): Seq[LineItem] = {
-    val lineItems = fetchLineItems(
-      session,
-      new StatementBuilder().where(s"orderId in (${orderIds.mkString(",")})").toStatement)
-    lineItems getOrElse Nil
+  def fetchLineItemsByOrder(service: LineItemServiceInterface, orderIds: Seq[Long]): Seq[LineItem] = {
+    fetchLineItems(
+      service,
+      new StatementBuilder().where(s"orderId in (${orderIds.mkString(",")})").toStatement
+    )
   }
 
   def fetchSuggestedLineItems(
     campaignName: String,
     clientName: String,
-    session: DfpSession,
+    service: LineItemServiceInterface,
     orderIds: Seq[Long]
   ): Seq[LineItem] = {
 
     def fetch(nameCondition: String, orderId: Long): Seq[LineItem] = {
       Logger.info(s"Fetching line items to suggest in order $orderId with condition [$nameCondition]")
-      val lineItems = fetchLineItems(
-        session,
+      fetchLineItems(
+        service,
         new StatementBuilder()
         .where(s"orderId = :orderId AND $nameCondition")
         .withBindVariableValue("orderId", orderId)
         .toStatement
       )
-      lineItems getOrElse Nil
     }
 
     def nameCondition(name: String) = s"name like '%$name%'"
@@ -88,24 +77,7 @@ object Dfp {
     fetches.find(_.nonEmpty) getOrElse Nil
   }
 
-  private def fetchLineItems(session: DfpSession, statement: Statement): Try[Seq[LineItem]] = {
-    val start = System.currentTimeMillis
-    val lineItemService = new DfpServices().get(session, classOf[LineItemServiceInterface])
-    val result = Try(lineItemService.getLineItemsByStatement(statement)) map { page =>
-
-      // assuming only one page of results
-      safeSeq(page.getResults)
-    }
-    result match {
-      case Failure(e) =>
-        Logger.error("Fetching line items failed", e)
-      case Success(items) =>
-        Logger.info(s"Fetched ${items.size} line items in ${System.currentTimeMillis - start} ms")
-    }
-    result
-  }
-
-  def fetchStatsReport(session: DfpSession, lineItemIds: Seq[Long]): Option[BufferedSource] = {
+  def fetchStatsReport(service: ReportServiceInterface, lineItemIds: Seq[Long]): Option[BufferedSource] = {
 
     if (lineItemIds.isEmpty) None
 
@@ -127,7 +99,7 @@ object Dfp {
       )
 
       val start = System.currentTimeMillis
-      val report = fetchReport(session, qry)
+      val report = fetchReport(service, qry)
       report match {
         case Failure(e) =>
           Logger.error(s"Stats report on line items ${lineItemIds.mkString(", ")} failed: ${e.getMessage}")
@@ -140,17 +112,92 @@ object Dfp {
     }
   }
 
-  private def fetchReport(session: DfpSession, qry: ReportQuery): Try[BufferedSource] = {
+  def getCampaignIdCustomFieldValue(lineItem: LineItem): Option[String] = {
+    safeSeq(lineItem.getCustomFieldValues) find {
+      _.getCustomFieldId == dfpCampaignFieldId
+    } map {
+      _.asInstanceOf[CustomFieldValue].getValue.asInstanceOf[TextValue].getValue
+    }
+  }
 
-    val reportService = new DfpServices().get(session, classOf[ReportServiceInterface])
+  def hasCampaignIdCustomFieldValue(campaignId: String)(lineItem: LineItem): Boolean =
+    getCampaignIdCustomFieldValue(lineItem) contains campaignId
+
+  def linkLineItemToCampaign(service: LineItemServiceInterface, lineItemId: Long, campaignId: String): Unit = {
+    fetchLineItemById(service, lineItemId) foreach { item =>
+      val currCampaignId = getCampaignIdCustomFieldValue(item)
+      if (currCampaignId.isDefined) {
+        Logger.error(s"Line item $lineItemId is already linked to campaign ${currCampaignId.get}")
+      } else {
+        appendCustomFieldToLineItem(service, item, new CustomFieldValue(dfpCampaignFieldId, new TextValue(campaignId)))
+      }
+    }
+  }
+
+  private def appendCustomFieldToLineItem(
+    service: LineItemServiceInterface,
+    item: LineItem,
+    field: CustomFieldValue
+  ): Unit = {
+    val currFields = safeSeq(item.getCustomFieldValues)
+    if (!currFields.contains(field)) {
+      item.setCustomFieldValues(currFields.toArray :+ field)
+      updateLineItem(service, item)
+    }
+  }
+}
+
+sealed trait DfpService {
+
+  System.setProperty("api.dfp.soapRequestTimeout", "300000")
+
+  def mkSession(): DfpSession = {
+    new DfpSession.Builder()
+    .withOAuth2Credential(
+      new OfflineCredentials.Builder()
+      .forApi(DFP)
+      .withClientSecrets(dfpClientId, dfpClientSecret)
+      .withRefreshToken(dfpRefreshToken)
+      .build()
+      .generateCredential()
+    )
+    .withApplicationName(dfpAppName)
+    .withNetworkCode(dfpNetworkCode)
+    .build()
+  }
+
+  def mkLineItemService(session: DfpSession): LineItemServiceInterface =
+    new DfpServices().get(session, classOf[LineItemServiceInterface])
+
+  def mkReportService(session: DfpSession): ReportServiceInterface =
+    new DfpServices().get(session, classOf[ReportServiceInterface])
+
+  def fetchLineItems(service: LineItemServiceInterface, statement: Statement): Seq[LineItem] = {
+    val start = System.currentTimeMillis
+    val result = Try(service.getLineItemsByStatement(statement)) map { page =>
+
+      // assuming only one page of results
+      safeSeq(page.getResults)
+    }
+    result match {
+      case Failure(e) =>
+        Logger.error("Fetching line items failed", e)
+        Nil
+      case Success(items) =>
+        Logger.info(s"Fetched ${items.size} line items in ${System.currentTimeMillis - start} ms")
+        items
+    }
+  }
+
+  def fetchReport(service: ReportServiceInterface, qry: ReportQuery): Try[BufferedSource] = {
 
     val reportJob = {
       val job = new ReportJob()
       job.setReportQuery(qry)
-      reportService.runReportJob(job)
+      service.runReportJob(job)
     }
 
-    val reportDownloader = new ReportDownloader(reportService, reportJob.getId)
+    val reportDownloader = new ReportDownloader(service, reportJob.getId)
     Try(reportDownloader.waitForReportReady()) map { completed =>
 
       val source = {
@@ -164,14 +211,16 @@ object Dfp {
     }
   }
 
-  def hasCampaignIdCustomFieldValue(campaignId: String)(lineItem: LineItem): Boolean = {
-    safeSeq(lineItem.getCustomFieldValues) exists { value =>
-      value.getCustomFieldId == dfpCampaignFieldId &&
-      value.asInstanceOf[CustomFieldValue].getValue.asInstanceOf[TextValue].getValue.toLowerCase == campaignId
+  def updateLineItem(service: LineItemServiceInterface, lineItem: LineItem): Unit = {
+    Try(service.updateLineItems(Array(lineItem))) match {
+      case Failure(e) =>
+        Logger.error(s"Failed to update line item ${lineItem.getId}", e)
+      case Success(updated) =>
+        if (updated.length != 1) Logger.error(s"Failed to update line item ${lineItem.getId}")
     }
   }
 
-  private def safeSeq[T](ts: Array[T]): Seq[T] = Option(ts).map(_.toSeq).getOrElse(Nil)
+  def safeSeq[T](ts: Array[T]): Seq[T] = Option(ts).map(_.toSeq).getOrElse(Nil)
 }
 
 object StopWords {

--- a/conf/routes
+++ b/conf/routes
@@ -29,6 +29,7 @@ POST /api/campaigns/import                controllers.CampaignApi.importFromTag(
 POST /api/campaigns/:id/refreshFromCAPI   controllers.CampaignApi.refreshCampaignFromCAPI(id: String)
 GET /api/campaigns/:id/drivers            controllers.CampaignApi.getCampaignTrafficDrivers(id: String)
 GET /api/campaigns/:id/suggest-drivers    controllers.CampaignApi.getSuggestedCampaignTrafficDrivers(id: String)
+PUT /api/campaigns/:id/driver/:driverId   controllers.CampaignApi.acceptSuggestedCampaignTrafficDriver(id: String, driverId: Long)
 GET /api/campaigns/:id/driverstats        controllers.CampaignApi.getCampaignTrafficDriverStats(id: String)
 GET /api/campaigns/:id/ctastats           controllers.CampaignApi.getCampaignCtaStats(id: String)
 


### PR DESCRIPTION
This provides an API endpoint to link a traffic driver to a campaign.

Next step is to use this endpoint in the campaign page, and integrate it with the suggestions functionality in #61.

/cc @guardian/labs-beta 