### PR TITLE
Sw hmac on management

### DIFF
--- a/app/controllers/ManagementApi.scala
+++ b/app/controllers/ManagementApi.scala
@@ -12,7 +12,7 @@ import repositories.{AnalyticsDataCache, GoogleAnalytics}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class ManagementApi(override val wsClient: WSClient) extends Controller with HMACAuthActions with PandaAuthActions {
+class ManagementApi(override val wsClient: WSClient) extends Controller with HMACPandaAuthActions {
 
   implicit val ec = ExecutionContext.fromExecutor(Executors.newCachedThreadPool())
 
@@ -61,5 +61,4 @@ class ManagementApi(override val wsClient: WSClient) extends Controller with HMA
     }
   }
 
-  override def secret: String = "getthisfroms3"
 }

--- a/app/controllers/PandaAuthActions.scala
+++ b/app/controllers/PandaAuthActions.scala
@@ -1,6 +1,7 @@
 package controllers
 
-import com.amazonaws.auth.{AWSCredentialsProvider}
+import com.amazonaws.auth.AWSCredentialsProvider
+import com.gu.pandahmac.HMACAuthActions
 import com.gu.pandomainauth.PanDomain
 import com.gu.pandomainauth.action.AuthActions
 import com.gu.pandomainauth.model.AuthenticatedUser
@@ -24,4 +25,9 @@ trait PandaAuthActions extends AuthActions {
     PanDomain.guardianValidation(authedUser)
   }
 
+}
+
+trait HMACPandaAuthActions extends PandaAuthActions with HMACAuthActions {
+
+  override def secret: String = Config().pandaHMACSecret
 }

--- a/app/services/Config.scala
+++ b/app/services/Config.scala
@@ -22,10 +22,12 @@ object Config extends AwsInstanceTags {
 }
 
 sealed trait Config {
+
   def stage: String
 
   def pandaDomain: String
   def pandaAuthCallback: String
+  lazy val pandaHMACSecret = getRequiredRemoteStringProperty("panda.hmac.secret")
 
   def logShippingStreamName: Option[String] = None
 

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ lazy val dependencies = Seq(
   "com.amazonaws" % "aws-java-sdk" % "1.11.8",
   "ai.x" %% "play-json-extensions" % "0.8.0",
   "com.gu" % "pan-domain-auth-play_2-5_2.11" % "0.4.0",
-  "com.gu" %% "panda-hmac" % "1.2.0-SNAPSHOT",
+  "com.gu" %% "panda-hmac" % "1.2.0",
   "com.gu" %% "content-api-client" % "10.5",
   "com.google.apis" % "google-api-services-analyticsreporting" % "v4-rev10-1.22.0",
   "com.squareup.okhttp3" % "okhttp" % "3.4.1",

--- a/build.sbt
+++ b/build.sbt
@@ -14,6 +14,7 @@ lazy val dependencies = Seq(
   "com.amazonaws" % "aws-java-sdk" % "1.11.8",
   "ai.x" %% "play-json-extensions" % "0.8.0",
   "com.gu" % "pan-domain-auth-play_2-5_2.11" % "0.4.0",
+  "com.gu" %% "panda-hmac" % "1.2.0-SNAPSHOT",
   "com.gu" %% "content-api-client" % "10.5",
   "com.google.apis" % "google-api-services-analyticsreporting" % "v4-rev10-1.22.0",
   "com.squareup.okhttp3" % "okhttp" % "3.4.1",

--- a/conf/routes
+++ b/conf/routes
@@ -44,6 +44,7 @@ GET    /management/api/analytics                        controllers.ManagementAp
 POST   /management/api/analytics/:dataType/:key         controllers.ManagementApi.refreshAnalyticsCacheEntry(dataType: String, key: String)
 DELETE /management/api/analytics/:dataType/:key         controllers.ManagementApi.deleteAnalyticsCacheEntry(dataType: String, key: String)
 POST   /management/api/analytics/:dataType              controllers.ManagementApi.refreshAnalyticsCacheForType(dataType: String)
+POST   /management/api/refreshExpiringCampaigns         controllers.ManagementApi.refreshExpiringCampaigns
 
 GET /assets/*file                 controllers.Assets.versioned(path="/public", file: Asset)
 


### PR DESCRIPTION
Adds HMAC authentication on management api - see https://github.com/guardian/panda-hmac for 'details'

Adds a new endpoint to refresh expiring campaigns form capi, this will either update them to the dead state or prolong them if they have been extended in tag manager.