### PR TITLE
Avoid duplicating queries when looking up traffic driver suggestions

### DIFF
--- a/app/services/Config.scala
+++ b/app/services/Config.scala
@@ -114,7 +114,7 @@ object StagingDfpProperties {
   )
   val dfpMerchandisingOrderIds = Map(
     "hosted" -> Seq(550774092L),
-    "paidContent" -> Seq(550773372L)
+    "paidContent" -> Seq(550774092L)
   )
   val dfpCampaignFieldId: Long = 26412
 }


### PR DESCRIPTION
For example, for one campaign used to run this list of queries:
```
name like '%| something about cars |%'
name like '%| leffe |%'
name like '%| leffe |%'
name like '%something about cars%'
name like '%leffe%'
name like '%something%'
name like '%something%'
name like '%leffe%'
```
but after this change will run this list of queries:
```
name like '%| something about cars |%'
name like '%| leffe |%'
name like '%something about cars%'
name like '%leffe%'
name like '%something%'
```
