### PR TITLE
Daily analytics reports

### DIFF
--- a/app/controllers/CampaignApi.scala
+++ b/app/controllers/CampaignApi.scala
@@ -3,6 +3,7 @@ package controllers
 import model._
 import model.command.CommandError._
 import model.command.{ImportCampaignFromCAPICommand, RefreshCampaignFromCAPICommand}
+import model.reports.CtaClicksReport
 import org.joda.time.DateTime
 import play.api.Logger
 import play.api.libs.json.Json._
@@ -152,6 +153,6 @@ class CampaignApi(override val wsClient: WSClient) extends Controller with Panda
   }
 
   def getCampaignCtaStats(campaignId: String) = APIAuthAction { req =>
-    Ok(toJson(GoogleAnalytics.getCtaClicksForCampaign(campaignId)))
+    Ok(toJson(CtaClicksReport.getCtaClicksForCampaign(campaignId)))
   }
 }

--- a/app/controllers/CampaignApi.scala
+++ b/app/controllers/CampaignApi.scala
@@ -3,7 +3,7 @@ package controllers
 import model._
 import model.command.CommandError._
 import model.command.{ImportCampaignFromCAPICommand, RefreshCampaignFromCAPICommand}
-import model.reports.CtaClicksReport
+import model.reports.{CampaignPageViewsReport, CtaClicksReport}
 import org.joda.time.DateTime
 import play.api.Logger
 import play.api.libs.json.Json._
@@ -44,7 +44,8 @@ class CampaignApi(override val wsClient: WSClient) extends Controller with Panda
   }
 
   def getCampaignAnalytics(id: String) = APIAuthAction { req =>
-    GoogleAnalytics.getAnalyticsForCampaign(id).map { c => Ok(Json.toJson(c)) } getOrElse NotFound
+    CampaignPageViewsReport.getCampaignPageViewsReport(id).map { c => Ok(Json.toJson(c)) } getOrElse NotFound
+    //GoogleAnalytics.getAnalyticsForCampaign(id).map { c => Ok(Json.toJson(c)) } getOrElse NotFound
   }
 
   def getCampaignContent(id: String) =  APIAuthAction { req =>

--- a/app/controllers/CampaignApi.scala
+++ b/app/controllers/CampaignApi.scala
@@ -44,8 +44,8 @@ class CampaignApi(override val wsClient: WSClient) extends Controller with Panda
   }
 
   def getCampaignAnalytics(id: String) = APIAuthAction { req =>
-    CampaignPageViewsReport.getCampaignPageViewsReport(id).map { c => Ok(Json.toJson(c)) } getOrElse NotFound
-    //GoogleAnalytics.getAnalyticsForCampaign(id).map { c => Ok(Json.toJson(c)) } getOrElse NotFound
+    //CampaignPageViewsReport.getCampaignPageViewsReport(id).map { c => Ok(Json.toJson(c)) } getOrElse NotFound
+    GoogleAnalytics.getAnalyticsForCampaign(id).map { c => Ok(Json.toJson(c)) } getOrElse NotFound
   }
 
   def getCampaignDailyUniqueUsers(id: String) = APIAuthAction { req =>

--- a/app/controllers/CampaignApi.scala
+++ b/app/controllers/CampaignApi.scala
@@ -3,7 +3,7 @@ package controllers
 import model._
 import model.command.CommandError._
 import model.command.{ImportCampaignFromCAPICommand, RefreshCampaignFromCAPICommand}
-import model.reports.{CampaignPageViewsReport, CtaClicksReport, DailyUniqueUsersReport}
+import model.reports.{CampaignPageViewsReport, CampaignTargetsReport, CtaClicksReport, DailyUniqueUsersReport}
 import org.joda.time.DateTime
 import play.api.Logger
 import play.api.libs.json.Json._
@@ -50,6 +50,10 @@ class CampaignApi(override val wsClient: WSClient) extends Controller with Panda
 
   def getCampaignDailyUniqueUsers(id: String) = APIAuthAction { req =>
     DailyUniqueUsersReport.getDailyUniqueUsersReport(id).map { c => Ok(Json.toJson(c)) } getOrElse NotFound
+  }
+
+  def getCampaignTargetsReport(id: String) = APIAuthAction { req =>
+    CampaignTargetsReport.getCampaignTargetsReport(id).map { c => Ok(Json.toJson(c)) } getOrElse NotFound
   }
 
   def getCampaignContent(id: String) =  APIAuthAction { req =>

--- a/app/controllers/CampaignApi.scala
+++ b/app/controllers/CampaignApi.scala
@@ -3,7 +3,7 @@ package controllers
 import model._
 import model.command.CommandError._
 import model.command.{ImportCampaignFromCAPICommand, RefreshCampaignFromCAPICommand}
-import model.reports.{CampaignPageViewsReport, CtaClicksReport}
+import model.reports.{CampaignPageViewsReport, CtaClicksReport, DailyUniqueUsersReport}
 import org.joda.time.DateTime
 import play.api.Logger
 import play.api.libs.json.Json._
@@ -46,6 +46,10 @@ class CampaignApi(override val wsClient: WSClient) extends Controller with Panda
   def getCampaignAnalytics(id: String) = APIAuthAction { req =>
     CampaignPageViewsReport.getCampaignPageViewsReport(id).map { c => Ok(Json.toJson(c)) } getOrElse NotFound
     //GoogleAnalytics.getAnalyticsForCampaign(id).map { c => Ok(Json.toJson(c)) } getOrElse NotFound
+  }
+
+  def getCampaignDailyUniqueUsers(id: String) = APIAuthAction { req =>
+    DailyUniqueUsersReport.getDailyUniqueUsersReport(id).map { c => Ok(Json.toJson(c)) } getOrElse NotFound
   }
 
   def getCampaignContent(id: String) =  APIAuthAction { req =>

--- a/app/controllers/ManagementApi.scala
+++ b/app/controllers/ManagementApi.scala
@@ -5,6 +5,7 @@ import java.util.concurrent.Executors
 import com.gu.pandahmac.HMACAuthActions
 import model.{TrafficDriverGroupStats, User}
 import model.command.RefreshCampaignFromCAPICommand
+import model.reports.CtaClicksReport
 import play.api.Logger
 import play.api.libs.json._
 import play.api.libs.ws.WSClient
@@ -52,7 +53,7 @@ class ManagementApi(override val wsClient: WSClient) extends Controller with HMA
       }
       case "CtaClicksReport" => {
         Logger.info(s"manually clearing GA CTA CTR analytics for $key")
-        Future {GoogleAnalytics.getCtaClicksForCampaign(key)}
+        Future {CtaClicksReport.getCtaClicksForCampaign(key)}
       }
       case "TrafficDriverGroupStats" => {
         Logger.info(s"manually clearing Traffic driver stats for $key")

--- a/app/model/reports/AnalyticsDataCacheEntry.scala
+++ b/app/model/reports/AnalyticsDataCacheEntry.scala
@@ -1,0 +1,64 @@
+package model.reports
+
+import ai.x.play.json.Jsonx
+import com.amazonaws.services.dynamodbv2.document.Item
+import play.api.Logger
+import play.api.libs.json.{Format, Json}
+import util.Compression
+
+import scala.util.control.NonFatal
+
+case class AnalyticsDataCacheEntrySummary(key: String, dataType: String, expires: Option[Long], written: Long)
+
+object AnalyticsDataCacheEntrySummary {
+  implicit val analyticsDataCacheEntrySummaryFormat: Format[AnalyticsDataCacheEntrySummary] = Jsonx.formatCaseClass[AnalyticsDataCacheEntrySummary]
+
+  def fromItem(item: Item) = try {
+    Json.parse(item.toJSON).as[AnalyticsDataCacheEntrySummary]
+  } catch {
+    case NonFatal(e) => {
+      Logger.error(s"failed to parse analytics data cache item summary ${item.toJSON}", e)
+      throw e
+    }
+  }
+}
+
+case class AnalyticsDataCacheEntry(key: String, dataType: String, data: String, expires: Option[Long], written: Long) {
+  //def toItem = Item.fromJSON(Json.toJson(this).toString())
+
+  def toItem = {
+    val item = new Item()
+      .withString("key", key)
+      .withString("dataType", dataType)
+      .withBinary("compressedData", Compression.compress(data))
+      .withLong("written", written)
+
+    expires.foreach(item.withLong("expires", _))
+
+    item
+  }
+
+}
+
+object AnalyticsDataCacheEntry {
+  implicit val analyticsDataCacheEntryFormat: Format[AnalyticsDataCacheEntry] = Jsonx.formatCaseClass[AnalyticsDataCacheEntry]
+
+  def fromItem(item: Item) = try {
+    if (item.isPresent("compressedData")) {
+      AnalyticsDataCacheEntry(
+        key = item.getString("key"),
+        dataType = item.getString("dataType"),
+        data = Compression.decompress(item.getBinary("compressedData")),
+        expires = if(item.isPresent("expires")) Some(item.getLong("expires")) else None,
+        written = item.getLong("written")
+      )
+    } else {
+      Json.parse(item.toJSON).as[AnalyticsDataCacheEntry]
+    }
+  } catch {
+    case NonFatal(e) => {
+      Logger.error(s"failed to parse analytics data cache item ${item.toJSON}", e)
+      throw e
+    }
+  }
+}

--- a/app/model/reports/CampaignPageViewsReport.scala
+++ b/app/model/reports/CampaignPageViewsReport.scala
@@ -18,7 +18,7 @@ case class CampaignPageViewsReport(campaignId: String, seenPaths: Set[String], p
       lastData <- pageCountStats.lastOption;
       lastSeenDate <- lastData.get("date")
     ) {
-      val missingDays = DateBasedReport.calculateDatesToFetch(new DateTime(lastSeenDate).plusDays(1), DateTime.now)
+      val missingDays = DateBasedReport.calculateDatesToFetch(new DateTime(lastSeenDate).plusDays(1), campaign.endDate)
       val dailyReports = missingDays.map(CampaignPageViewsReport.loadCampaignPageViewsForDay(campaign, _))
 
       val refreshed = dailyReports.foldLeft(this) { case (report: CampaignPageViewsReport, (date: DateTime, dailyViewCounts: DailyViewCounts)) =>
@@ -125,7 +125,7 @@ object CampaignPageViewsReport {
       campaign <- CampaignRepository.getCampaign(campaignId);
       startDate <- campaign.startDate
     ) yield {
-      val dailyReports = DateBasedReport.calculateDatesToFetch(startDate, DateTime.now).map{ dt =>
+      val dailyReports = DateBasedReport.calculateDatesToFetch(startDate, campaign.endDate).map{ dt =>
         Thread.sleep(1000) // try to avoid rate limiting
         loadCampaignPageViewsForDay(campaign, dt)
       }

--- a/app/model/reports/CampaignPageViewsReport.scala
+++ b/app/model/reports/CampaignPageViewsReport.scala
@@ -1,0 +1,197 @@
+package model.reports
+
+import ai.x.play.json.Jsonx
+import model.Campaign
+import org.joda.time.DateTime
+import play.api.Logger
+import play.api.libs.json.Format
+import repositories.GoogleAnalytics.DailyViewCounts
+import repositories._
+
+import scala.concurrent.Future
+
+
+case class CampaignPageViewsReport(campaignId: String, seenPaths: Set[String], pageCountStats: List[Map[String, Long]]) {
+  def refresh = {
+    val refreshed = for (
+      campaign <- CampaignRepository.getCampaign(campaignId);
+      lastData <- pageCountStats.lastOption;
+      lastSeenDate <- lastData.get("date")
+    ) {
+      val missingDays = CampaignPageViewsReport.calculateDatesToFetch(new DateTime(lastSeenDate).plusDays(1), DateTime.now)
+      val dailyReports = missingDays.map(CampaignPageViewsReport.loadCampaignPageViewsForDay(campaign, _))
+
+      val refreshed = dailyReports.foldLeft(this) { case (report: CampaignPageViewsReport, (date: DateTime, dailyViewCounts: DailyViewCounts)) =>
+        report.addDayCounts(date, dailyViewCounts)
+      }
+      AnalyticsDataCache.putCampaignPageViewsReport(campaignId, refreshed, AnalyticsDataCache.calculateValidToDateForDailyStats(campaign))
+
+      refreshed
+    }
+
+  }
+
+  def addDayCounts(date: DateTime, dailyViewCounts: DailyViewCounts): CampaignPageViewsReport = {
+
+    val newPaths = dailyViewCounts.seenPaths -- seenPaths
+    val backfilledCurrentStats = backfillNewPathData(newPaths, pageCountStats)
+
+    val missingPathsInNewData = seenPaths -- dailyViewCounts.seenPaths
+    val newDayCounts = addMissingPathsToIncomingData(missingPathsInNewData, dailyViewCounts.countStats)
+
+    val newCountsWithRunningTotals = backfilledCurrentStats.lastOption match{
+      case Some(latest) => addRunningTotals(latest, newDayCounts)
+      case None => initialiseRunningTotals(newDayCounts)
+    }
+
+    val newCountsWithDate = newCountsWithRunningTotals + ("date" -> date.getMillis)
+
+    CampaignPageViewsReport(campaignId, seenPaths ++ dailyViewCounts.seenPaths, pageCountStats :+ newCountsWithDate)
+  }
+
+  private def addMissingPathsToIncomingData(missingPathsInNewData: Set[String], dailyViewCounts: Map[String, Long]): Map[String, Long] = {
+    val zeroedStatsByPath = missingPathsInNewData map { p =>
+      Map(
+        s"count$p" -> 0L,
+        s"unique$p" -> 0L
+      )
+    }
+    val zeroedStats = zeroedStatsByPath.fold(Map())(_ ++ _)
+    dailyViewCounts ++ zeroedStats
+  }
+
+  private def backfillNewPathData(newPaths: Set[String], stats: List[Map[String, Long]]) = {
+    val backfillZeroedStatsByPath = newPaths map { p =>
+      Map(
+        s"count$p" -> 0L,
+        s"unique$p" -> 0L,
+        s"cumulative-count$p" -> 0L,
+        s"cumulative-unique$p" -> 0L
+      )
+    }
+    val backfillZeroedStats = backfillZeroedStatsByPath.fold(Map())(_ ++ _)
+    stats.map { dayStats =>
+      dayStats ++ backfillZeroedStats
+    }
+  }
+
+  def addRunningTotals(latestCurrentStats: Map[String, Long], newDayCounts: Map[String, Long]): Map[String, Long] = {
+    newDayCounts.keys.foldLeft(newDayCounts){case (counts, statName) =>
+      val cumalativeStatName = s"cumulative-$statName"
+      counts + (cumalativeStatName -> (latestCurrentStats.getOrElse(cumalativeStatName, 0L) + newDayCounts(statName)))
+    }
+  }
+
+  def initialiseRunningTotals(newDayCounts: Map[String, Long]): Map[String, Long] = {
+    newDayCounts.keys.foldLeft(newDayCounts){case (counts, statName) =>
+      counts + (s"cumulative-$statName" -> newDayCounts(statName))
+    }
+  }
+
+}
+
+object CampaignPageViewsReport {
+
+  implicit val ec = AnalyticsDataCache.analyticsExectuionContext
+
+  implicit val campaignPageViewsReportFormat: Format[CampaignPageViewsReport] = Jsonx.formatCaseClass[CampaignPageViewsReport]
+
+  def getCampaignPageViewsReport(campaignId: String): Option[CampaignPageViewsReport] = {
+
+    AnalyticsDataCache.getCampaignPageViewsReport(campaignId) match {
+      case Hit(report) => {
+        Logger.debug(s"getting page view report for campaign $campaignId - cache hit")
+        Some(report)
+      }
+      case Stale(report) => {
+        Logger.debug(s"getting page view report for campaign $campaignId - cache stale spawning async refresh")
+
+        Future{
+          Logger.debug(s"async refresh of page view report for campaign $campaignId")
+          report.refresh
+        } // serve stale but spawn refresh future
+        Some(report)
+      }
+      case Miss => {
+        Logger.debug(s"getting page view report for campaign $campaignId - cache miss fetching sync")
+
+        generateReport(campaignId)
+      }
+    }
+  }
+
+  def generateReport(campaignId: String): Option[CampaignPageViewsReport] = {
+    for (
+      campaign <- CampaignRepository.getCampaign(campaignId);
+      startDate <- campaign.startDate
+    ) yield {
+      val dailyReports = calculateDatesToFetch(startDate, DateTime.now).map(loadCampaignPageViewsForDay(campaign, _))
+
+      val emptyReport = CampaignPageViewsReport(campaignId, Set(), Nil)
+      val report = dailyReports.foldLeft(emptyReport) { case (report: CampaignPageViewsReport, (date: DateTime, dailyViewCounts: DailyViewCounts)) =>
+        report.addDayCounts(date, dailyViewCounts)
+      }
+
+      AnalyticsDataCache.putCampaignPageViewsReport(campaignId, report, AnalyticsDataCache.calculateValidToDateForDailyStats(campaign))
+
+      report
+    }
+  }
+
+  def loadCampaignPageViewsForDay(campaign: Campaign, date: DateTime) = {
+    val dailyCounts = if (campaign.`type` == "hosted") {
+      campaign.gaFilterExpression.flatMap(GoogleAnalytics.loadPageViewsForDay(_, date))
+    } else {
+      val contentStats = for (
+        content <- CampaignContentRepository.getContentForCampaign(campaign.id).filter(_.isLive);
+        path <- content.path
+      ) yield {
+        val gaFilter = s"ga:pagePath==/$path"
+        GoogleAnalytics.loadPageViewsForDay(gaFilter, date)
+      }
+
+      val pathStats = contentStats.flatten
+
+      if(pathStats.isEmpty) {
+        Some(DailyViewCounts(Set(), Map()))
+      } else {
+        Some(pathStats.reduce { (a: DailyViewCounts, b: DailyViewCounts) =>
+          DailyViewCounts(
+            seenPaths = a.seenPaths ++ b.seenPaths,
+            countStats = a.countStats ++ b.countStats
+          )
+        })
+      }
+    }
+
+    date -> calculateDailyTotals(dailyCounts)
+  }
+
+  private def calculateDailyTotals(dailyViewCounts: Option[DailyViewCounts]): DailyViewCounts = {
+    dailyViewCounts match {
+      case Some(DailyViewCounts(seenPaths, countStats)) => {
+        val stats = countStats.keySet
+
+        val totalCount = stats.filter(_.startsWith("count")).foldLeft(0L){case(total, k) => total + countStats(k)}
+        val totalUnique = stats.filter(_.startsWith("unique")).foldLeft(0L){case(total, k) => total + countStats(k)}
+
+        DailyViewCounts(seenPaths, countStats ++ Map("count-total" -> totalCount, "unique-total" -> totalUnique))
+      }
+      case None =>
+        DailyViewCounts(seenPaths = Set(), countStats = Map("count-total" -> 0L, "unique-total" -> 0L))
+    }
+  }
+
+  def calculateDatesToFetch(startDate: DateTime, endDate: DateTime): List[DateTime] = {
+    var date = startDate.withTimeAtStartOfDay()
+    val endDay = endDate.withTimeAtStartOfDay()
+    var daysInRange: List[DateTime] = Nil
+
+    while (date.isBefore(endDay)) {
+      daysInRange = daysInRange :+ date
+      date = date.plusDays(1)
+    }
+
+    daysInRange
+  }
+}

--- a/app/model/reports/CampaignTargetsReport.scala
+++ b/app/model/reports/CampaignTargetsReport.scala
@@ -31,7 +31,7 @@ object CampaignTargetsReport {
     ) yield {
 
       val campaignLength = new Duration(startDate, endDate).getStandardDays
-      val reportRange = DateBasedReport.calculateDatesToFetch(startDate, DateTime.now)
+      val reportRange = DateBasedReport.calculateDatesToFetch(startDate, campaign.endDate)
 
       CampaignTargetsReport(
         campaign.targets.keys.map { targetName =>

--- a/app/model/reports/CampaignTargetsReport.scala
+++ b/app/model/reports/CampaignTargetsReport.scala
@@ -1,0 +1,50 @@
+package model.reports
+
+import ai.x.play.json.Jsonx
+import org.joda.time.{DateTime, Duration}
+import play.api.libs.json.Format
+import repositories.CampaignRepository
+
+case class CampaignTargetRunRateElement(date: DateTime, expected: Long)
+
+object CampaignTargetRunRateElement {
+  implicit val campaignTargetRunRateElemenFormat: Format[CampaignTargetRunRateElement] = Jsonx.formatCaseClass[CampaignTargetRunRateElement]
+}
+
+case class CampaignTarget(target: Long, runRate: List[CampaignTargetRunRateElement])
+
+object CampaignTarget {
+  implicit val campaignTargetFormat: Format[CampaignTarget] = Jsonx.formatCaseClass[CampaignTarget]
+}
+
+case class CampaignTargetsReport(targets: Map[String, CampaignTarget])
+
+object CampaignTargetsReport {
+
+  implicit val campaignTargetsReportFormat: Format[CampaignTargetsReport] = Jsonx.formatCaseClass[CampaignTargetsReport]
+
+  def getCampaignTargetsReport(campaignId: String): Option[CampaignTargetsReport] = {
+    for (
+      campaign <- CampaignRepository.getCampaign(campaignId);
+      startDate <- campaign.startDate;
+      endDate <- campaign.endDate
+    ) yield {
+
+      val campaignLength = new Duration(startDate, endDate).getStandardDays
+      val reportRange = DateBasedReport.calculateDatesToFetch(startDate, DateTime.now)
+
+      CampaignTargetsReport(
+        campaign.targets.keys.map { targetName =>
+          val target = campaign.targets(targetName)
+          val dailyRunRate = target.toDouble / campaignLength
+
+          val runRate = reportRange.map{ date =>
+            val daysIn = new Duration(startDate, date).getStandardDays
+            CampaignTargetRunRateElement(date, (daysIn * dailyRunRate).toLong)
+          }
+          targetName -> CampaignTarget(target, runRate)
+        }.toMap
+      )
+    }
+  }
+}

--- a/app/model/reports/CtaClicksReport.scala
+++ b/app/model/reports/CtaClicksReport.scala
@@ -1,0 +1,64 @@
+package model.reports
+
+import ai.x.play.json.Jsonx
+import play.api.Logger
+import play.api.libs.json.Format
+import repositories._
+
+import scala.concurrent.Future
+
+// the data is CTA atom id -> number of clicks
+case class CtaClicksReport(campaignId: String, data: Map[String, Long]) {
+
+  def refresh = CtaClicksReport.generateReport(campaignId)
+}
+
+object CtaClicksReport {
+
+  implicit val ec = AnalyticsDataCache.analyticsExectuionContext
+
+  implicit val actaClicksReportyFormat: Format[CtaClicksReport] = Jsonx.formatCaseClass[CtaClicksReport]
+
+  def getCtaClicksForCampaign(campaignId: String): Option[CtaClicksReport] = {
+
+    AnalyticsDataCache.getCampaignCtaClicksReport(campaignId) match {
+      case Hit(report) => {
+        Logger.debug(s"getting CTA clicks for campaign $campaignId - cache hit")
+        Some(report)
+      }
+      case Stale(report) => {
+        Logger.debug(s"getting CTA clicks for campaign $campaignId - cache stale spawning async refresh")
+
+        Future{
+          Logger.debug(s"async refresh of CTA clicks for campaign $campaignId")
+          report.refresh
+        } // serve stale but spawn refresh future
+        Some(report)
+      }
+      case Miss => {
+        Logger.debug(s"getting CTA clicks for campaign $campaignId - cache miss fetching sync")
+
+        generateReport(campaignId)
+      }
+    }
+  }
+
+  def generateReport(campaignId: String): Option[CtaClicksReport] = {
+    CampaignRepository.getCampaign(campaignId) map { campaign =>
+      val reportLines = for (
+        cta <- campaign.callToActions;
+        startDate <- campaign.startDate;
+        builderId <- cta.builderId;
+        trackingCode <- cta.trackingCode
+      ) yield {
+        builderId -> GoogleAnalytics.loadCtaClicks(trackingCode, startDate, campaign.endDate)
+      }
+
+      val report = CtaClicksReport(campaignId, reportLines.toMap)
+
+      AnalyticsDataCache.putCampaignCtaClicksReport(campaignId, report, AnalyticsDataCache.calculateValidToDateForDailyStats(campaign))
+
+      report
+    }
+  }
+}

--- a/app/model/reports/DailyUniqueUsersReport.scala
+++ b/app/model/reports/DailyUniqueUsersReport.scala
@@ -21,7 +21,7 @@ case class DailyUniqueUsersReport(campaignId: String, dailyUniqueUsers: List[Dai
       campaign <- CampaignRepository.getCampaign(campaignId);
       lastData <- dailyUniqueUsers.lastOption
     ) {
-      val missingDays = CampaignPageViewsReport.calculateDatesToFetch(lastData.date.plusDays(1), DateTime.now)
+      val missingDays = DateBasedReport.calculateDatesToFetch(lastData.date.plusDays(1), DateTime.now)
       val dailyReports = missingDays.map(DailyUniqueUsersReport.loadCampaignDailyUniquesForDay(campaign, _))
 
       val refreshed = dailyReports.foldLeft(this) { case (report: DailyUniqueUsersReport, (date: DateTime, dailyUniqueUsers: Long)) =>
@@ -84,7 +84,7 @@ object DailyUniqueUsersReport {
       campaign <- CampaignRepository.getCampaign(campaignId);
       startDate <- campaign.startDate
     ) yield {
-      val dailyReports = calculateDatesToFetch(startDate, DateTime.now).map{ dt =>
+      val dailyReports = DateBasedReport.calculateDatesToFetch(startDate, DateTime.now).map{ dt =>
         Thread.sleep(1000) // try to avoid rate limiting
         loadCampaignDailyUniquesForDay(campaign, dt)
       }
@@ -110,20 +110,4 @@ object DailyUniqueUsersReport {
     date -> dailyCount.getOrElse(0L)
   }
 
-  val GA_SWITCH_ON_DATE = new DateTime("2016-07-01")
-
-  def calculateDatesToFetch(startDate: DateTime, endDate: DateTime): List[DateTime] = {
-
-    val sd = if(startDate.isBefore(GA_SWITCH_ON_DATE)) GA_SWITCH_ON_DATE else startDate
-    var date = sd.withTimeAtStartOfDay()
-    val endDay = endDate.withTimeAtStartOfDay()
-    var daysInRange: List[DateTime] = Nil
-
-    while (date.isBefore(endDay)) {
-      daysInRange = daysInRange :+ date
-      date = date.plusDays(1)
-    }
-
-    daysInRange
-  }
 }

--- a/app/model/reports/DailyUniqueUsersReport.scala
+++ b/app/model/reports/DailyUniqueUsersReport.scala
@@ -1,0 +1,129 @@
+package model.reports
+
+import ai.x.play.json.Jsonx
+import model.Campaign
+import org.joda.time.DateTime
+import play.api.Logger
+import play.api.libs.json.Format
+import repositories._
+
+import scala.concurrent.Future
+
+case class DailyUniqueUserEntry(date: DateTime, uniqueUsers: Long, cumulativeUniqueUsers: Long)
+
+object DailyUniqueUserEntry{
+  implicit val dailyUniqueUserEntryFormat: Format[DailyUniqueUserEntry] = Jsonx.formatCaseClass[DailyUniqueUserEntry]
+}
+
+case class DailyUniqueUsersReport(campaignId: String, dailyUniqueUsers: List[DailyUniqueUserEntry]) {
+  def refresh = {
+    val refreshed = for (
+      campaign <- CampaignRepository.getCampaign(campaignId);
+      lastData <- dailyUniqueUsers.lastOption
+    ) {
+      val missingDays = CampaignPageViewsReport.calculateDatesToFetch(lastData.date.plusDays(1), DateTime.now)
+      val dailyReports = missingDays.map(DailyUniqueUsersReport.loadCampaignDailyUniquesForDay(campaign, _))
+
+      val refreshed = dailyReports.foldLeft(this) { case (report: DailyUniqueUsersReport, (date: DateTime, dailyUniqueUsers: Long)) =>
+        report.addDayCounts(date, dailyUniqueUsers)
+      }
+      AnalyticsDataCache.putDailyUniqueUsersReport(campaignId, refreshed, AnalyticsDataCache.calculateValidToDateForDailyStats(campaign))
+
+      refreshed
+    }
+
+  }
+
+  def addDayCounts(date: DateTime, dailyUniqueCount: Long): DailyUniqueUsersReport = {
+
+    dailyUniqueUsers.lastOption match{
+      case Some(latest) => {
+        val newData = DailyUniqueUserEntry(date, dailyUniqueCount, latest.cumulativeUniqueUsers + dailyUniqueCount)
+        DailyUniqueUsersReport(campaignId, dailyUniqueUsers :+ newData)
+      }
+      case None => {
+        val newData = DailyUniqueUserEntry(date, dailyUniqueCount, dailyUniqueCount)
+        DailyUniqueUsersReport(campaignId, List(newData))
+      }
+    }
+  }
+}
+
+object DailyUniqueUsersReport {
+
+  implicit val ec = AnalyticsDataCache.analyticsExectuionContext
+
+  implicit val dailyUniqueUsersReportFormat: Format[DailyUniqueUsersReport] = Jsonx.formatCaseClass[DailyUniqueUsersReport]
+
+  def getDailyUniqueUsersReport(campaignId: String): Option[DailyUniqueUsersReport] = {
+
+    AnalyticsDataCache.getDailyUniqueUsersReport(campaignId) match {
+      case Hit(report) => {
+        Logger.debug(s"getting daily unique users report for campaign $campaignId - cache hit")
+        Some(report)
+      }
+      case Stale(report) => {
+        Logger.debug(s"getting daily unique users report for campaign $campaignId - cache stale spawning async refresh")
+
+        Future{
+          Logger.debug(s"async refresh of daily unique users report for campaign $campaignId")
+          report.refresh
+        } // serve stale but spawn refresh future
+        Some(report)
+      }
+      case Miss => {
+        Logger.debug(s"getting daily unique users report for campaign $campaignId - cache miss fetching sync")
+
+        generateReport(campaignId)
+      }
+    }
+  }
+
+  def generateReport(campaignId: String): Option[DailyUniqueUsersReport] = {
+    for (
+      campaign <- CampaignRepository.getCampaign(campaignId);
+      startDate <- campaign.startDate
+    ) yield {
+      val dailyReports = calculateDatesToFetch(startDate, DateTime.now).map{ dt =>
+        Thread.sleep(1000) // try to avoid rate limiting
+        loadCampaignDailyUniquesForDay(campaign, dt)
+      }
+
+      val emptyReport = DailyUniqueUsersReport(campaignId, Nil)
+      val report = dailyReports.foldLeft(emptyReport) { case (report: DailyUniqueUsersReport, (date: DateTime, dailyUniqueCount: Long)) =>
+        report.addDayCounts(date, dailyUniqueCount)
+      }
+
+      AnalyticsDataCache.putDailyUniqueUsersReport(campaignId, report, AnalyticsDataCache.calculateValidToDateForDailyStats(campaign))
+
+      report
+    }
+  }
+
+  def loadCampaignDailyUniquesForDay(campaign: Campaign, date: DateTime) = {
+    val dailyCount = if (campaign.`type` == "hosted") {
+      campaign.gaFilterExpression.map(GoogleAnalytics.loadUniqueUsersDay(_, date))
+    } else {
+      campaign.pathPrefix.map{ section => GoogleAnalytics.loadUniqueUsersDay(s"ga:dimension4==${section}", date)}
+    }
+
+    date -> dailyCount.getOrElse(0L)
+  }
+
+  val GA_SWITCH_ON_DATE = new DateTime("2016-07-01")
+
+  def calculateDatesToFetch(startDate: DateTime, endDate: DateTime): List[DateTime] = {
+
+    val sd = if(startDate.isBefore(GA_SWITCH_ON_DATE)) GA_SWITCH_ON_DATE else startDate
+    var date = sd.withTimeAtStartOfDay()
+    val endDay = endDate.withTimeAtStartOfDay()
+    var daysInRange: List[DateTime] = Nil
+
+    while (date.isBefore(endDay)) {
+      daysInRange = daysInRange :+ date
+      date = date.plusDays(1)
+    }
+
+    daysInRange
+  }
+}

--- a/app/model/reports/DailyUniqueUsersReport.scala
+++ b/app/model/reports/DailyUniqueUsersReport.scala
@@ -21,7 +21,7 @@ case class DailyUniqueUsersReport(campaignId: String, dailyUniqueUsers: List[Dai
       campaign <- CampaignRepository.getCampaign(campaignId);
       lastData <- dailyUniqueUsers.lastOption
     ) {
-      val missingDays = DateBasedReport.calculateDatesToFetch(lastData.date.plusDays(1), DateTime.now)
+      val missingDays = DateBasedReport.calculateDatesToFetch(lastData.date.plusDays(1), campaign.endDate)
       val dailyReports = missingDays.map(DailyUniqueUsersReport.loadCampaignDailyUniquesForDay(campaign, _))
 
       val refreshed = dailyReports.foldLeft(this) { case (report: DailyUniqueUsersReport, (date: DateTime, dailyUniqueUsers: Long)) =>
@@ -84,7 +84,7 @@ object DailyUniqueUsersReport {
       campaign <- CampaignRepository.getCampaign(campaignId);
       startDate <- campaign.startDate
     ) yield {
-      val dailyReports = DateBasedReport.calculateDatesToFetch(startDate, DateTime.now).map{ dt =>
+      val dailyReports = DateBasedReport.calculateDatesToFetch(startDate, campaign.endDate).map{ dt =>
         Thread.sleep(1000) // try to avoid rate limiting
         loadCampaignDailyUniquesForDay(campaign, dt)
       }

--- a/app/model/reports/DateBasedReport.scala
+++ b/app/model/reports/DateBasedReport.scala
@@ -6,11 +6,14 @@ object DateBasedReport {
 
   val GA_SWITCH_ON_DATE = new DateTime("2016-07-01")
 
-  def calculateDatesToFetch(startDate: DateTime, endDate: DateTime): List[DateTime] = {
+  def calculateDatesToFetch(startDate: DateTime, campaignEndDate: Option[DateTime]): List[DateTime] = {
 
     val sd = if(startDate.isBefore(GA_SWITCH_ON_DATE)) GA_SWITCH_ON_DATE else startDate
+    val endDate = campaignEndDate.map(_.plusDays(1)).find(_.isBeforeNow) getOrElse(DateTime.now)
+
     var date = sd.withTimeAtStartOfDay()
     val endDay = endDate.withTimeAtStartOfDay()
+
     var daysInRange: List[DateTime] = Nil
 
     while (date.isBefore(endDay)) {

--- a/app/model/reports/DateBasedReport.scala
+++ b/app/model/reports/DateBasedReport.scala
@@ -1,0 +1,23 @@
+package model.reports
+
+import org.joda.time.DateTime
+
+object DateBasedReport {
+
+  val GA_SWITCH_ON_DATE = new DateTime("2016-07-01")
+
+  def calculateDatesToFetch(startDate: DateTime, endDate: DateTime): List[DateTime] = {
+
+    val sd = if(startDate.isBefore(GA_SWITCH_ON_DATE)) GA_SWITCH_ON_DATE else startDate
+    var date = sd.withTimeAtStartOfDay()
+    val endDay = endDate.withTimeAtStartOfDay()
+    var daysInRange: List[DateTime] = Nil
+
+    while (date.isBefore(endDay)) {
+      daysInRange = daysInRange :+ date
+      date = date.plusDays(1)
+    }
+
+    daysInRange
+  }
+}

--- a/app/repositories/AnalyticsDataCache.scala
+++ b/app/repositories/AnalyticsDataCache.scala
@@ -3,7 +3,7 @@ package repositories
 import java.util.concurrent.Executors
 
 import com.amazonaws.services.dynamodbv2.document.spec.ScanSpec
-import model.reports.{AnalyticsDataCacheEntry, AnalyticsDataCacheEntrySummary, CtaClicksReport}
+import model.reports.{AnalyticsDataCacheEntry, AnalyticsDataCacheEntrySummary, CampaignPageViewsReport, CtaClicksReport}
 import model.{Campaign, CampaignDailyCountsReport, CampaignSummary, TrafficDriverGroupStats}
 import org.joda.time.DateTime
 import play.api.libs.json.{Json, Reads}
@@ -51,6 +51,11 @@ object AnalyticsDataCache {
     Dynamo.analyticsDataCacheTable.putItem(entry.toItem)
   }
 
+  def putCampaignPageViewsReport(campaignId: String, data: CampaignPageViewsReport, validToTimestamp: Option[Long]): Unit = {
+    val entry = AnalyticsDataCacheEntry(campaignId, "CampaignPageViewsReport", Json.toJson(data).toString(), validToTimestamp, System.currentTimeMillis())
+    Dynamo.analyticsDataCacheTable.putItem(entry.toItem)
+  }
+
   def putCampaignSummary(campaignId: String, data: CampaignSummary, validToTimestamp: Option[Long]): Unit = {
     val entry = AnalyticsDataCacheEntry(campaignId, "CampaignSummary", Json.toJson(data).toString(), validToTimestamp, System.currentTimeMillis())
     Dynamo.analyticsDataCacheTable.putItem(entry.toItem)
@@ -92,6 +97,10 @@ object AnalyticsDataCache {
 
   def getCampaignDailyCountsReport(campaignId: String): CacheResult[CampaignDailyCountsReport] = {
     getEntry[CampaignDailyCountsReport](campaignId, "CampaignDailyCountsReport")
+  }
+
+  def getCampaignPageViewsReport(campaignId: String): CacheResult[CampaignPageViewsReport] = {
+    getEntry[CampaignPageViewsReport](campaignId, "CampaignPageViewsReport")
   }
 
   def getCampaignSummary(campaignId: String): CacheResult[CampaignSummary] = {

--- a/app/repositories/AnalyticsDataCache.scala
+++ b/app/repositories/AnalyticsDataCache.scala
@@ -1,17 +1,16 @@
 package repositories
 
-import ai.x.play.json.Jsonx
-import com.amazonaws.services.dynamodbv2.document.Item
+import java.util.concurrent.Executors
+
 import com.amazonaws.services.dynamodbv2.document.spec.ScanSpec
-import model.{CampaignDailyCountsReport, CampaignSummary, TrafficDriverGroupStats}
+import model.reports.{AnalyticsDataCacheEntry, AnalyticsDataCacheEntrySummary, CtaClicksReport}
+import model.{Campaign, CampaignDailyCountsReport, CampaignSummary, TrafficDriverGroupStats}
 import org.joda.time.DateTime
-import play.api.Logger
-import play.api.libs.json.{Format, Json, Reads}
+import play.api.libs.json.{Json, Reads}
 import services.Dynamo
-import util.Compression
 
 import scala.collection.JavaConversions._
-import scala.util.control.NonFatal
+import scala.concurrent.ExecutionContext
 
 sealed trait CacheResult[+A] extends Product {
 
@@ -38,62 +37,10 @@ case object Miss extends CacheResult[Nothing] {
   def get = throw new NoSuchElementException("Miss.get")
 }
 
-case class AnalyticsDataCacheEntrySummary(key: String, dataType: String, expires: Option[Long], written: Long)
-
-object AnalyticsDataCacheEntrySummary {
-  implicit val analyticsDataCacheEntrySummaryFormat: Format[AnalyticsDataCacheEntrySummary] = Jsonx.formatCaseClass[AnalyticsDataCacheEntrySummary]
-
-  def fromItem(item: Item) = try {
-    Json.parse(item.toJSON).as[AnalyticsDataCacheEntrySummary]
-  } catch {
-    case NonFatal(e) => {
-      Logger.error(s"failed to parse analytics data cache item summary ${item.toJSON}", e)
-      throw e
-    }
-  }
-}
-
-case class AnalyticsDataCacheEntry(key: String, dataType: String, data: String, expires: Option[Long], written: Long) {
-  //def toItem = Item.fromJSON(Json.toJson(this).toString())
-
-  def toItem = {
-    val item = new Item()
-      .withString("key", key)
-      .withString("dataType", dataType)
-      .withBinary("compressedData", Compression.compress(data))
-      .withLong("written", written)
-
-    expires.foreach(item.withLong("expires", _))
-
-    item
-  }
-
-}
-
-object AnalyticsDataCacheEntry {
-  implicit val analyticsDataCacheEntryFormat: Format[AnalyticsDataCacheEntry] = Jsonx.formatCaseClass[AnalyticsDataCacheEntry]
-
-  def fromItem(item: Item) = try {
-    if (item.isPresent("compressedData")) {
-      AnalyticsDataCacheEntry(
-        key = item.getString("key"),
-        dataType = item.getString("dataType"),
-        data = Compression.decompress(item.getBinary("compressedData")),
-        expires = if(item.isPresent("expires")) Some(item.getLong("expires")) else None,
-        written = item.getLong("written")
-      )
-    } else {
-      Json.parse(item.toJSON).as[AnalyticsDataCacheEntry]
-    }
-  } catch {
-    case NonFatal(e) => {
-      Logger.error(s"failed to parse analytics data cache item ${item.toJSON}", e)
-      throw e
-    }
-  }
-}
 
 object AnalyticsDataCache {
+
+  implicit val analyticsExectuionContext = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(50))
 
   def deleteCacheEntry(key: String, dataType: String): Unit = {
     Dynamo.analyticsDataCacheTable.deleteItem("key", key, "dataType", dataType)
@@ -114,7 +61,7 @@ object AnalyticsDataCache {
     Dynamo.analyticsDataCacheTable.putItem(entry.toItem)
   }
 
-  def putCampaignCtaClicksReport(campaignId: String, data: Map[String, Long], validToTimestamp: Option[Long]): Unit = {
+  def putCampaignCtaClicksReport(campaignId: String, data: CtaClicksReport, validToTimestamp: Option[Long]): Unit = {
     val entry = AnalyticsDataCacheEntry(campaignId, "CtaClicksReport", Json.toJson(data).toString(), validToTimestamp, System.currentTimeMillis())
     Dynamo.analyticsDataCacheTable.putItem(entry.toItem)
   }
@@ -156,8 +103,8 @@ object AnalyticsDataCache {
 
   }
 
-  def getCampaignCtaClicksReport(campaignId: String): CacheResult[Map[String, Long]] = {
-    getEntry[Map[String, Long]](campaignId, "CtaClicksReport")
+  def getCampaignCtaClicksReport(campaignId: String): CacheResult[CtaClicksReport] = {
+    getEntry[CtaClicksReport](campaignId, "CtaClicksReport")
   }
 
   def summariseContents = {
@@ -168,4 +115,12 @@ object AnalyticsDataCache {
 
   def getCampaignTrafficDriverGroupStats( campaignId: String): CacheResult[Seq[TrafficDriverGroupStats]] =
     getEntry[Seq[TrafficDriverGroupStats]](campaignId, "TrafficDriverGroupStats")
+
+  def calculateValidToDateForDailyStats(campaign: Campaign): Option[Long] = {
+    val campaignFinished = for (
+      d <- campaign.endDate
+    ) yield {d.isBeforeNow}
+
+    if(campaignFinished.getOrElse(false)) None else { Some( DateTime.now().withTimeAtStartOfDay().plusDays(1).getMillis) }
+  }
 }

--- a/app/repositories/AnalyticsDataCache.scala
+++ b/app/repositories/AnalyticsDataCache.scala
@@ -3,7 +3,7 @@ package repositories
 import java.util.concurrent.Executors
 
 import com.amazonaws.services.dynamodbv2.document.spec.ScanSpec
-import model.reports.{AnalyticsDataCacheEntry, AnalyticsDataCacheEntrySummary, CampaignPageViewsReport, CtaClicksReport}
+import model.reports._
 import model.{Campaign, CampaignDailyCountsReport, CampaignSummary, TrafficDriverGroupStats}
 import org.joda.time.DateTime
 import play.api.libs.json.{Json, Reads}
@@ -56,6 +56,11 @@ object AnalyticsDataCache {
     Dynamo.analyticsDataCacheTable.putItem(entry.toItem)
   }
 
+  def putDailyUniqueUsersReport(campaignId: String, data: DailyUniqueUsersReport, validToTimestamp: Option[Long]): Unit = {
+    val entry = AnalyticsDataCacheEntry(campaignId, "DailyUniqueUsersReport", Json.toJson(data).toString(), validToTimestamp, System.currentTimeMillis())
+    Dynamo.analyticsDataCacheTable.putItem(entry.toItem)
+  }
+
   def putCampaignSummary(campaignId: String, data: CampaignSummary, validToTimestamp: Option[Long]): Unit = {
     val entry = AnalyticsDataCacheEntry(campaignId, "CampaignSummary", Json.toJson(data).toString(), validToTimestamp, System.currentTimeMillis())
     Dynamo.analyticsDataCacheTable.putItem(entry.toItem)
@@ -101,6 +106,10 @@ object AnalyticsDataCache {
 
   def getCampaignPageViewsReport(campaignId: String): CacheResult[CampaignPageViewsReport] = {
     getEntry[CampaignPageViewsReport](campaignId, "CampaignPageViewsReport")
+  }
+
+  def getDailyUniqueUsersReport(campaignId: String): CacheResult[DailyUniqueUsersReport] = {
+    getEntry[DailyUniqueUsersReport](campaignId, "DailyUniqueUsersReport")
   }
 
   def getCampaignSummary(campaignId: String): CacheResult[CampaignSummary] = {

--- a/app/services/Config.scala
+++ b/app/services/Config.scala
@@ -58,6 +58,7 @@ sealed trait Config {
   private val remoteConfiguration: Map[String, String] = loadRemoteConfiguration
 
   lazy val googleAnalyticsViewId = getRequiredRemoteStringProperty("googleAnalytivsViewId")
+  lazy val googleAnalyticsGlabsViewId = getRequiredRemoteStringProperty("googleAnalytivsGlabsViewId")
 
   lazy val capiKey = getRequiredRemoteStringProperty("capi.key")
   lazy val capiPreviewUrl = getRequiredRemoteStringProperty("capi.preview.url")

--- a/conf/routes
+++ b/conf/routes
@@ -21,6 +21,7 @@ GET /api/campaigns/:id                    controllers.CampaignApi.getCampaign(id
 PUT /api/campaigns/:id                    controllers.CampaignApi.updateCampaign(id: String)
 DELETE /api/campaigns/:id                 controllers.CampaignApi.deleteCampaign(id: String)
 GET /api/campaigns/:id/analytics          controllers.CampaignApi.getCampaignAnalytics(id: String)
+GET /api/campaigns/:id/dailyUniques       controllers.CampaignApi.getCampaignDailyUniqueUsers(id: String)
 GET /api/campaigns/:id/content            controllers.CampaignApi.getCampaignContent(id: String)
 GET /api/campaigns/:id/notes              controllers.CampaignApi.getCampaignNotes(id: String)
 POST /api/campaigns/:id/notes             controllers.CampaignApi.addCampaignNote(id: String)

--- a/conf/routes
+++ b/conf/routes
@@ -53,7 +53,7 @@ POST   /management/api/refreshExpiringCampaigns         controllers.ManagementAp
 GET /assets/*file                 controllers.Assets.versioned(path="/public", file: Asset)
 
 # Migration
-GET /migration/addCampaignTypes   controllers.Migration.addCampaignType()
+GET /migration/buildDailyReports   controllers.Migration.buildDailyReports
 
 
 # Management

--- a/conf/routes
+++ b/conf/routes
@@ -22,6 +22,7 @@ PUT /api/campaigns/:id                    controllers.CampaignApi.updateCampaign
 DELETE /api/campaigns/:id                 controllers.CampaignApi.deleteCampaign(id: String)
 GET /api/campaigns/:id/analytics          controllers.CampaignApi.getCampaignAnalytics(id: String)
 GET /api/campaigns/:id/dailyUniques       controllers.CampaignApi.getCampaignDailyUniqueUsers(id: String)
+GET /api/campaigns/:id/targetsReport      controllers.CampaignApi.getCampaignTargetsReport(id: String)
 GET /api/campaigns/:id/content            controllers.CampaignApi.getCampaignContent(id: String)
 GET /api/campaigns/:id/notes              controllers.CampaignApi.getCampaignNotes(id: String)
 POST /api/campaigns/:id/notes             controllers.CampaignApi.addCampaignNote(id: String)

--- a/public/actions/CampaignActions/getCampaignCtaStats.js
+++ b/public/actions/CampaignActions/getCampaignCtaStats.js
@@ -11,7 +11,7 @@ function requestCampaignCtaStats(id) {
 function receiveCampaignCtaStats(campaignCtaStats) {
     return {
         type:        'CAMPAIGN_CTA_STATS_GET_RECEIVE',
-        campaignCtaStats:    campaignCtaStats,
+        campaignCtaStats:    campaignCtaStats.data,
         receivedAt:  Date.now()
     };
 }


### PR DESCRIPTION
Refactors analytics queries to model them correctly, in doing so biting the bullet and allowing sampled reports in.

Adds daily uniques report and programatically derived targets report (rather than smooshing it all together).

The old reports are currently still active, but there is a migration to build the daily versions into the cache so they don't all need to be generated at once. This migration will be performed before the reports are used.