### PR TITLE
Remove old filtering

### DIFF
--- a/public/actions/UIActions/setCampaignStateFilter.js
+++ b/public/actions/UIActions/setCampaignStateFilter.js
@@ -1,9 +1,0 @@
-export const SET_CAMPAIGN_STATE_FILTER = 'SET_CAMPAIGN_STATE_FILTER';
-
-export function setCampaignStateFilter(campaignStateFilter) {
-    return {
-        type:       SET_CAMPAIGN_STATE_FILTER,
-        campaignStateFilter:    campaignStateFilter,
-        receivedAt: Date.now()
-    };
-}

--- a/public/actions/UIActions/setCampaignTypeFilter.js
+++ b/public/actions/UIActions/setCampaignTypeFilter.js
@@ -1,9 +1,0 @@
-export const SET_CAMPAIGN_TYPE_FILTER = 'SET_CAMPAIGN_TYPE_FILTER';
-
-export function setCampaignTypeFilter(campaignTypeFilter) {
-    return {
-        type:       SET_CAMPAIGN_TYPE_FILTER,
-        campaignTypeFilter:    campaignTypeFilter,
-        receivedAt: Date.now()
-    };
-}

--- a/public/components/CampaignList/CampaignListItem.js
+++ b/public/components/CampaignList/CampaignListItem.js
@@ -69,7 +69,7 @@ class CampaignListItem extends React.Component {
 
     return (
       <tr className="campaign-list__row" onClick={this.redirectToCampaign}>
-        <td className="campaign-list__item">{this.props.campaign.name}<br/>{image}</td>
+        <td className="campaign-list__item">{this.props.campaign.name}{image}</td>
         <td className="campaign-list__item">{this.props.campaign.type}</td>
         <td className="campaign-list__item">{this.props.campaign.status}</td>
         <td className="campaign-list__item">{this.props.campaign.actualValue}</td>

--- a/public/components/Campaigns/Campaigns.js
+++ b/public/components/Campaigns/Campaigns.js
@@ -10,10 +10,10 @@ class Campaigns extends Component {
   filterCampaigns = (campaigns) => {
     var filtered = campaigns;
 
-    var stateFilter = this.props.location.query.state;
+    var stateFilter = this.props.location.query.state || 'live';
     var typeFilter = this.props.location.query.type;
 
-    if (stateFilter) {
+    if (stateFilter && stateFilter !== 'all') {
       filtered = filtered.filter((c) => c.status === stateFilter);
     }
 

--- a/public/components/Campaigns/Campaigns.js
+++ b/public/components/Campaigns/Campaigns.js
@@ -98,8 +98,6 @@ function mapStateToProps(state) {
   return {
     campaigns: state.campaigns,
     overallAnalyticsSummary: state.overallAnalyticsSummary,
-    campaignStateFilter: state.campaignStateFilter,
-    campaignTypeFilter: state.campaignTypeFilter,
     campaignSortColumn: state.campaignSort.campaignSortColumn,
     campaignSortOrder: state.campaignSort.campaignSortOrder
   };

--- a/public/components/Sidebar/Sidebar.js
+++ b/public/components/Sidebar/Sidebar.js
@@ -27,10 +27,10 @@ class Sidebar extends React.Component {
           <SidebarLink to="/campaigns">All Campaigns</SidebarLink>
           <div className="sidebar__filter-group">
             <div className="sidebar__filter-group__header">State:</div>
-            {this.filterLink({state: undefined}, 'All')}
+            {this.filterLink({state: 'all'}, 'All')}
             {this.filterLink({state: 'prospect'}, 'Prospects')}
             {this.filterLink({state: 'production'}, 'In Production')}
-            {this.filterLink({state: 'live'}, 'Live')}
+            {this.filterLink({state: undefined}, 'Live')}
             {this.filterLink({state: 'dead'}, 'Dead')}
           </div>
           <div className="sidebar__filter-group">

--- a/public/components/Sidebar/Sidebar.js
+++ b/public/components/Sidebar/Sidebar.js
@@ -1,15 +1,7 @@
 import React, { PropTypes } from 'react';
 import {Link} from 'react-router';
 
-class Sidebar extends React.Component {
-
-  setCampaignStateFilter = (f) => {
-    this.props.uiActions.setCampaignStateFilter(f);
-  };
-
-  setCampaignTypeFilter = (f) => {
-    this.props.uiActions.setCampaignTypeFilter(f);
-  };
+export default class Sidebar extends React.Component {
 
   filterLink = (changeValue, displayName) => {
     var query = Object.assign({}, this.props.query, changeValue);
@@ -63,24 +55,3 @@ class SidebarLink extends React.Component {
     </Link>;
   }
 }
-
-//REDUX CONNECTIONS
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
-import * as setCampaignStateFilter from '../../actions/UIActions/setCampaignStateFilter';
-import * as setCampaignTypeFilter from '../../actions/UIActions/setCampaignTypeFilter';
-
-function mapStateToProps(state) {
-  return {
-    campaignStateFilter: state.campaignStateFilter,
-    campaignTypeFilter: state.campaignTypeFilter
-  };
-}
-
-function mapDispatchToProps(dispatch) {
-  return {
-    uiActions: bindActionCreators(Object.assign({}, setCampaignStateFilter, setCampaignTypeFilter), dispatch)
-  };
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(Sidebar);

--- a/public/reducers/campaignStateFilterReducer.js
+++ b/public/reducers/campaignStateFilterReducer.js
@@ -1,9 +1,0 @@
-export default function error(state = false, action) {
-  switch (action.type) {
-    case 'SET_CAMPAIGN_STATE_FILTER':
-      return action.campaignStateFilter;
-
-    default:
-      return state;
-  }
-}

--- a/public/reducers/campaignTypeFilterReducer.js
+++ b/public/reducers/campaignTypeFilterReducer.js
@@ -1,9 +1,0 @@
-export default function error(state = false, action) {
-  switch (action.type) {
-    case 'SET_CAMPAIGN_TYPE_FILTER':
-      return action.campaignTypeFilter;
-
-    default:
-      return state;
-  }
-}

--- a/public/reducers/rootReducer.js
+++ b/public/reducers/rootReducer.js
@@ -13,8 +13,6 @@ import campaignTrafficDriverSuggestions from './campaignTrafficDriverSuggestions
 import campaignTrafficDriversDirty from './campaignTrafficDriversDirtyReducer';
 import campaignTrafficDriverStats from './campaignTrafficDriverStatsReducer';
 import campaignNotes from './campaignNotesReducer';
-import campaignStateFilter from './campaignStateFilterReducer';
-import campaignTypeFilter from './campaignTypeFilterReducer';
 import campaignSort from './campaignSortReducer';
 import overallAnalyticsSummary from './overallAnalyticsSummaryReducer';
 
@@ -33,8 +31,6 @@ export default combineReducers({
   campaignTrafficDriversDirty,
   campaignTrafficDriverStats,
   campaignNotes,
-  campaignStateFilter,
-  campaignTypeFilter,
   campaignSort,
   overallAnalyticsSummary
 });

--- a/public/styles/components/campaigns-list/_campaigns-list.scss
+++ b/public/styles/components/campaigns-list/_campaigns-list.scss
@@ -172,6 +172,7 @@
   margin-right: 20px;
   margin-bottom: 20px;
   padding: 15px;
+  max-width: 330px;
 
   border-top: 1px solid $c-grey-400;
   border-right: 1px solid $c-grey-400;
@@ -194,6 +195,7 @@
 }
 
 .campaign-list__item__logo {
-  max-width: 100px;
-  padding-top: 10px;
+  max-width: 60px;
+  padding: 3px;
+  float:right;
 }


### PR DESCRIPTION
- Remove redux actions no longer needed after implementing filtering with query parameters, see https://github.com/guardian/campaign-central/pull/74

- Implemented change to default campaigns view as per feedback document:

__Change homepage to just include live campaigns__
"Because this is the campaigns we care about the most and most analysed" - Rob

- Tweak campaign list logos sizing/positioning to be more compact:

"Remove or reduce logos sizes so we can get more in" - Rob

CC @steppenwells @kelvin-chappell 

