### PR TITLE
Campaigns sorting

### DIFF
--- a/public/components/CampaignList/CampaignList.js
+++ b/public/components/CampaignList/CampaignList.js
@@ -8,6 +8,7 @@ class CampaignList extends React.Component {
   };
 
   static defaultProps = {
+    campaignSortColumn: 'endDate',
     campaigns: []
   };
 
@@ -21,19 +22,13 @@ class CampaignList extends React.Component {
     }
 
     //set an opposite sort order
-    order = !order;
-
-    return order;
+    return !order;
   };
 
   setHeaderCssClass = (column) => {
-    let sortedColumn = this.props.campaignSortColumn || 'endDate';
+    let sortedColumn = this.props.campaignSortColumn;
     let order = this.getSortOrder(column) ? 'asc' : 'desc';
     let newCssClass = 'campaign-list__header-order';
-
-    if (!this.props.campaignSortColumn) { //after page load, when we don't have campaignSortColumn prop yet
-      order = 'desc'; //order is always desc
-    }
 
     if (column === sortedColumn) {
       newCssClass = 'campaign-list__header-order--' + order;

--- a/public/components/Campaigns/Campaigns.js
+++ b/public/components/Campaigns/Campaigns.js
@@ -7,6 +7,10 @@ class Campaigns extends Component {
     campaigns: PropTypes.array.isRequired,
   }
 
+  static defaultProps = {
+    campaignSortColumn: 'endDate',
+  }
+
   filterCampaigns = (campaigns) => {
     var filtered = campaigns;
 
@@ -38,38 +42,22 @@ class Campaigns extends Component {
       case 'name':
       case 'type':
       case 'status':
-        if (typeof value === 'undefined') {
-          value = "";
-        }
-        value.toUpperCase();
-        break;
+        return (value || "").toUpperCase();
       case 'actualValue':
       case 'startDate':
-        if (typeof value === 'undefined') {
-          value = 0;
-        }
-        value = parseInt(value, 10);
+        return parseInt(value || 0, 10);
       case 'endDate':
-        if (typeof value === 'undefined') {
-          value = Infinity;
-        }
-      default:
-        value;
+        return value || Infinity;
     }
 
     return value;
-  }
+  };
 
   sortCampaigns = (campaigns) => {
-    let sorted = campaigns;
     let column = this.props.campaignSortColumn;
     let order = this.props.campaignSortOrder || false;
 
-    sorted = sorted.sort(this.sortBy(column, order, function(value) {
-      return this.prepareSortValues(column, value);
-    }.bind(this)));
-
-    return sorted;
+    return campaigns.sort(this.sortBy(column, order, this.prepareSortValues.bind(this, column)));
   }
 
   componentDidMount() {

--- a/public/styles/components/error-bar/_error-bar.scss
+++ b/public/styles/components/error-bar/_error-bar.scss
@@ -1,9 +1,9 @@
 .error-bar {
   position: absolute;
-  width: 100%;
   background-color: $c-orange;
 
-  margin-left: $size-sidebar-width;
+  left: $size-sidebar-width;
+  right:0;
 
   z-index: 10;
 


### PR DESCRIPTION
Fixes the default sorting (sort by end date on load wasn't working) and simplifies sort functions a bit.

![image](https://cloud.githubusercontent.com/assets/6290008/21648678/b77025f2-d296-11e6-8202-27194735eaa4.png)


Also stop the error bar from spilling off the screen:

![image](https://cloud.githubusercontent.com/assets/6290008/21648585/65992738-d296-11e6-9fee-9a02b99ef9bb.png)

CC: @steppenwells @kelvin-chappell 