### PR TITLE
CampaignList sorting overhaul

### DIFF
--- a/public/components/CampaignList/CampaignList.js
+++ b/public/components/CampaignList/CampaignList.js
@@ -27,9 +27,9 @@ class CampaignList extends React.Component {
 
   sortableColumnHead = (columnName, displayName) => {
     return (
-      <th onClick={ () => this.setCampaignSort(columnName) } className={"campaign-list__header campaign-list__header--sortable " + columnName}>
-        <span>{displayName}</span>
-        <span className={'campaign-list__header-order ' + this.sortOrderClass(columnName) }> &nbsp; </span>
+      <th onClick={ () => this.setCampaignSort(columnName) } className="campaign-list__header campaign-list__header--sortable">
+        <span className="campaign-list__header-title">{displayName}</span>
+        <i className={'campaign-list__header-order ' + this.sortOrderClass(columnName) }/>
       </th>
     )
   };

--- a/public/components/CampaignList/CampaignList.js
+++ b/public/components/CampaignList/CampaignList.js
@@ -9,36 +9,29 @@ class CampaignList extends React.Component {
 
   static defaultProps = {
     campaignSortColumn: 'endDate',
+    campaignSortOrder: 1, //asc
     campaigns: []
   };
 
-  getSortOrder = (column) => {
-    let order = false; //false = DESC, true = ASC
-    let DOMNode = this.refs['sort-' + column];
-    let cssClass = DOMNode ? DOMNode.className : '';
+  sortOrderClass = (column) => {
+    let order = this.props.campaignSortOrder === 1 ? 'asc' : 'desc';
 
-    if (cssClass.substring(cssClass.length - 3) === 'asc') {
-      order = true;
-    }
-
-    //set an opposite sort order
-    return !order;
+    return column === this.props.campaignSortColumn ? 'campaign-list__header-order--' + order : '';
   };
 
-  setHeaderCssClass = (column) => {
-    let sortedColumn = this.props.campaignSortColumn;
-    let order = this.getSortOrder(column) ? 'asc' : 'desc';
-    let newCssClass = 'campaign-list__header-order';
-
-    if (column === sortedColumn) {
-      newCssClass = 'campaign-list__header-order--' + order;
-    }
-
-    return newCssClass;
+  setCampaignSort = (column) => {
+    var currentColumn = this.props.campaignSortColumn;
+    var currentOrder = this.props.campaignSortOrder;
+    this.props.uiActions.setCampaignSort(column, column !== currentColumn ? 1 : -currentOrder);
   };
 
-  setCampaignSort = (c) => {
-    this.props.uiActions.setCampaignSort(c, this.getSortOrder(c));
+  sortableColumnHead = (columnName, displayName) => {
+    return (
+      <th onClick={ () => this.setCampaignSort(columnName) } className={"campaign-list__header campaign-list__header--sortable " + columnName}>
+        <span>{displayName}</span>
+        <span className={'campaign-list__header-order ' + this.sortOrderClass(columnName) }> &nbsp; </span>
+      </th>
+    )
   };
 
   render () {
@@ -54,30 +47,12 @@ class CampaignList extends React.Component {
       <table className="campaign-list">
         <thead>
           <tr>
-            <th onClick={ () => this.setCampaignSort('name') } className="campaign-list__header--sortable name">
-              <span> Name </span>
-              <span className={ this.setHeaderCssClass('name') } ref="sort-name"> &nbsp; </span>
-            </th>
-            <th onClick={ () => this.setCampaignSort('type') } className="campaign-list__header--sortable type">
-              <span> Type </span>
-              <span className={ this.setHeaderCssClass('type') } ref="sort-type"> &nbsp; </span>
-            </th>
-            <th onClick={ () => this.setCampaignSort('status') } className="campaign-list__header--sortable status">
-              <span> Status </span>
-              <span className={ this.setHeaderCssClass('status') } ref="sort-status"> &nbsp; </span>
-            </th>
-            <th onClick={ () => this.setCampaignSort('actualValue') } className="campaign-list__header--sortable actualValue">
-              <span> Value </span>
-              <span className={ this.setHeaderCssClass('actualValue') } ref="sort-actualValue"> &nbsp; </span>
-            </th>
-            <th onClick={ () => this.setCampaignSort('startDate') } className="campaign-list__header--sortable startDate">
-              <span> Start date </span>
-              <span className={ this.setHeaderCssClass('startDate') } ref="sort-startDate"> &nbsp; </span>
-            </th>
-            <th onClick={ () => this.setCampaignSort('endDate') } className="campaign-list__header--sortable endDate">
-              <span> Finish date </span>
-              <span className={ this.setHeaderCssClass('endDate') } ref="sort-endDate"> &nbsp; </span>
-            </th>
+            {this.sortableColumnHead('name', 'Name')}
+            {this.sortableColumnHead('type', 'Type')}
+            {this.sortableColumnHead('status', 'Status')}
+            {this.sortableColumnHead('actualValue', 'Value')}
+            {this.sortableColumnHead('startDate', 'Start date')}
+            {this.sortableColumnHead('endDate', 'Finish date')}
             <th className="campaign-list__header">Days left</th>
             <th className="campaign-list__header">Target</th>
             <th className="campaign-list__header">Uniques</th>

--- a/public/components/Campaigns/Campaigns.js
+++ b/public/components/Campaigns/Campaigns.js
@@ -9,6 +9,7 @@ class Campaigns extends Component {
 
   static defaultProps = {
     campaignSortColumn: 'endDate',
+    campaignSortOrder: 1, //asc
   }
 
   filterCampaigns = (campaigns) => {
@@ -27,13 +28,11 @@ class Campaigns extends Component {
     return filtered;
   }
 
-  sortBy = (field, reverse, iteratees) => {
+  sortBy = (field, order, iteratees) => {
     let key = function(x) {return iteratees ? iteratees(x[field]) : x[field]};
 
-    reverse = !reverse ? 1 : -1;
-
     return function (a, b) {
-      return a = key(a), b = key(b), reverse * ((a > b) - (b > a));
+      return a = key(a), b = key(b), order * ((a > b) - (b > a));
     }
   }
 
@@ -55,7 +54,7 @@ class Campaigns extends Component {
 
   sortCampaigns = (campaigns) => {
     let column = this.props.campaignSortColumn;
-    let order = this.props.campaignSortOrder || false;
+    let order = this.props.campaignSortOrder;
 
     return campaigns.sort(this.sortBy(column, order, this.prepareSortValues.bind(this, column)));
   }

--- a/public/styles/components/campaigns-list/_campaigns-list.scss
+++ b/public/styles/components/campaigns-list/_campaigns-list.scss
@@ -22,97 +22,40 @@
   position: relative;
 }
 
+.campaign-list__header-title {
+  user-select: none;
+}
+
 .campaign-list__header-order {
+  display: inline-block;
+  width: 10px;
+  height: 15px;
+  position: relative;
+  margin-left: 5px;
   &::before, &::after {
     content: "";
-    position: absolute;
-    right: 0;
     display: block;
-    cursor: pointer;
-
-    width: 0;
-    height: 0;
-
     border-left: 5px solid transparent;
     border-right: 5px solid transparent;
-  }
-
-  &::after {
-    border-bottom: 7px solid $c-highlight-main;
-    top: 14px;
+    box-sizing: border-box;
   }
 
   &::before {
+    border-bottom: 7px solid $c-highlight-main;
+    margin-bottom: 5px;
+  }
+
+  &::after {
     border-top: 7px solid $c-highlight-main;
-    top: 26px;
   }
+
 }
 
-.campaign-list__header-order--desc::before,
-.campaign-list__header-order--asc::after {
-  display: none;
+.campaign-list__header-order--desc::after,
+.campaign-list__header-order--asc::before {
+  visibility: hidden;
 }
 
-
-
-.campaign-list__header--sortable.name {
-  min-width: 270px;
-  [class^='campaign-list__header-order'] {
-    &::after,
-    &::before {
-      right: 38%;
-    }
-  }
-}
-
-.campaign-list__header--sortable.type {
-  min-width: 100px;
-  [class^='campaign-list__header-order'] {
-    &::after,
-    &::before {
-      right: 22%;
-    }
-  }
-}
-
-.campaign-list__header--sortable.status {
-  [class^='campaign-list__header-order'] {
-    &::after,
-    &::before {
-      right: 12%;
-    }
-  }
-}
-
-.campaign-list__header--sortable.actualValue {
-  min-width: 80px;
-  [class^='campaign-list__header-order'] {
-    &::after,
-    &::before {
-      right: 9%;
-    }
-  }
-}
-
-.campaign-list__header--sortable.startDate {
-  min-width: 114px;
-  [class^='campaign-list__header-order'] {
-    &::after,
-    &::before {
-      right: 8%;
-    }
-  }
-}
-
-.campaign-list__header--sortable.endDate {
-  min-width: 164px;
-  [class^='campaign-list__header-order'] {
-    &::after,
-    &::before {
-      right: 19%;
-    }
-  }
-}
 
 .campaign-list__row {
   background-color: $c-grey-200;

--- a/public/styles/components/campaigns-list/_campaigns-list.scss
+++ b/public/styles/components/campaigns-list/_campaigns-list.scss
@@ -2,7 +2,7 @@
   border-collapse: collapse;
 }
 
-%campaign-list__header {
+.campaign-list__header {
   padding: 15px;
 
   background: $c-grey-main;
@@ -13,81 +13,47 @@
   font-size: 18px;
 }
 
-.campaign-list__header {
-  @extend %campaign-list__header;
-}
-
 .campaign-list__header:last-child {
   border-right: none;
 }
 
-%sortable-arrow-down {
-  cursor: pointer;
-
-  width: 0;
-  height: 0;
-
-  border-left: 5px solid transparent;
-  border-right: 5px solid transparent;
-  border-top: 7px solid $c-highlight-main;
-
-  position: absolute;
-  top: 26px;
-  right: 0;
-}
-
-%sortable-arrow-up {
-  cursor: pointer;
-
-  width: 0;
-  height: 0;
-
-  border-left: 5px solid transparent;
-  border-right: 5px solid transparent;
-  border-bottom: 7px solid $c-highlight-main;
-
-  position: absolute;
-  top: 14px;
-  right: 0;
-}
-
-%pseudo-element {
-  content: " ";
-  display: block;
-}
-
 .campaign-list__header--sortable {
-  @extend %campaign-list__header;
-
   cursor: pointer;
   position: relative;
+}
 
-  .campaign-list__header-order {
-    &::after {
-      @extend %pseudo-element;
-      @extend %sortable-arrow-up;
-    }
+.campaign-list__header-order {
+  &::before, &::after {
+    content: "";
+    position: absolute;
+    right: 0;
+    display: block;
+    cursor: pointer;
 
-    &::before {
-      @extend %pseudo-element;
-      @extend %sortable-arrow-down;
-    }
+    width: 0;
+    height: 0;
+
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
   }
 
-  .campaign-list__header-order--desc {
-    &::before {
-      @extend %pseudo-element;
-      @extend %sortable-arrow-up;
-    }
+  &::after {
+    border-bottom: 7px solid $c-highlight-main;
+    top: 14px;
   }
 
-  .campaign-list__header-order--asc {
-    &::after {
-      @extend %pseudo-element;
-      @extend %sortable-arrow-down;
-    }
+  &::before {
+    border-top: 7px solid $c-highlight-main;
+    top: 26px;
   }
 }
+
+.campaign-list__header-order--desc::before,
+.campaign-list__header-order--asc::after {
+  display: none;
+}
+
+
 
 .campaign-list__header--sortable.name {
   min-width: 270px;


### PR DESCRIPTION
- Use `props.campaignSortOrder` to determine current sort order rather than css classes
- Use `1`/`-1` as values of `campaignSortOrder` instead of `true`/`false`
- Reduce duplication in column headers mark-up
- Fix styling of arrows so they don't need to each be positioned separately
- Get rid of unnecessary mixins etc in CSS

CC @guardian/labs-beta 