### PR TITLE
Enable rejection of traffic driver suggestions

### DIFF
--- a/app/controllers/CampaignApi.scala
+++ b/app/controllers/CampaignApi.scala
@@ -157,6 +157,12 @@ class CampaignApi(override val wsClient: WSClient) extends Controller with Panda
     NoContent
   }
 
+  def rejectSuggestedCampaignTrafficDriver(campaignId: String, lineItemId: Long) = APIAuthAction { req =>
+    Logger.info(s"Rejecting traffic driver $lineItemId for campaign $campaignId")
+    LineItemSummary.rejectSuggestedTrafficDriver(campaignId, lineItemId)
+    NoContent
+  }
+
   def getCampaignTrafficDriverStats(campaignId: String) = APIAuthAction { req =>
     Logger.info(s"Loading traffic driver stats for campaign $campaignId")
     Ok(toJson(TrafficDriverGroupStats.forCampaign(campaignId)))

--- a/app/model/TrafficDriver.scala
+++ b/app/model/TrafficDriver.scala
@@ -212,7 +212,13 @@ object LineItemSummary {
     } yield {
       val dfpLineItemService = Dfp.mkLineItemService(Dfp.mkSession())
       def fetch(orderIds: Seq[Long]): Seq[LineItemSummary] =
-        Dfp.fetchSuggestedLineItems(campaign.name, client.name, dfpLineItemService, orderIds) filterNot {
+        Dfp.fetchSuggestedLineItems(
+          campaignName = campaign.name,
+          clientName = client.name,
+          service = dfpLineItemService,
+          orderIds,
+          lineItemIdsToIgnore = TrafficDriverRejectRepository.getRejectedDriverIds(campaignId)
+        ) filterNot {
           // DFP won't let you update archived line items
           _.getIsArchived
         } map {
@@ -228,6 +234,10 @@ object LineItemSummary {
 
   def acceptSuggestedTrafficDriver(campaignId: String, lineItemId: Long): Unit = {
     Dfp.linkLineItemToCampaign(Dfp.mkLineItemService(Dfp.mkSession()), lineItemId, campaignId)
+  }
+
+  def rejectSuggestedTrafficDriver(campaignId: String, lineItemId: Long): Unit = {
+    TrafficDriverRejectRepository.putRejectedDriverId(campaignId, lineItemId)
   }
 }
 

--- a/app/repositories/TrafficDriverRejectRepository.scala
+++ b/app/repositories/TrafficDriverRejectRepository.scala
@@ -1,0 +1,35 @@
+package repositories
+
+import com.amazonaws.services.dynamodbv2.document.Item
+import play.api.Logger
+import services.Dynamo
+
+import scala.collection.JavaConverters._
+import scala.util.control.NonFatal
+
+object TrafficDriverRejectRepository {
+
+  def getRejectedDriverIds(campaignId: String): Seq[Long] = {
+    try {
+      val items = Dynamo.trafficDriverRejectTable.query("campaignId", campaignId).asScala
+      items.map(_.getNumber("lineItemId").longValue).toSeq
+    } catch {
+      case NonFatal(e) =>
+        Logger.error(s"Failed to fetch rejected traffic drivers for campaign $campaignId", e)
+        Nil
+    }
+  }
+
+  def putRejectedDriverId(campaignId: String, lineItemId: Long): Unit = {
+    try {
+      val item = Item.fromMap(Map[String, AnyRef](
+        "campaignId" -> campaignId,
+        "lineItemId" -> long2Long(lineItemId)
+      ).asJava)
+      Dynamo.trafficDriverRejectTable.putItem(item)
+    } catch {
+      case NonFatal(e) =>
+        Logger.error(s"Failed to store rejected traffic driver $lineItemId for campaign $campaignId", e)
+    }
+  }
+}

--- a/app/services/AWS.scala
+++ b/app/services/AWS.scala
@@ -63,5 +63,5 @@ object Dynamo {
   lazy val campaignContentTable = dynamoDb.getTable(Config().campaignContentTableName)
   lazy val clientTable = dynamoDb.getTable(Config().clientTableName)
   lazy val analyticsDataCacheTable = dynamoDb.getTable(Config().analyticsDataCacheTableName)
-
+  lazy val trafficDriverRejectTable = dynamoDb.getTable(Config().trafficDriverRejectTableName)
 }

--- a/app/services/Config.scala
+++ b/app/services/Config.scala
@@ -39,6 +39,8 @@ sealed trait Config {
 
   def analyticsDataCacheTableName = s"campaign-central-$stage-analytics"
 
+  def trafficDriverRejectTableName = s"campaign-central-$stage-drivers-rejected"
+
   def tagManagerApiUrl: String
   def composerUrl: String
   def liveUrl: String
@@ -186,7 +188,7 @@ class ProdConfig extends Config {
       "paidContent" -> Seq(paid)
     )
   }
-  val dfpMerchandisingOrderIds = {
+  override val dfpMerchandisingOrderIds = {
     val hosted = 345535767L
     val paid = 211298847L
     val paidUs = 211064247L

--- a/app/services/Dfp.scala
+++ b/app/services/Dfp.scala
@@ -39,7 +39,8 @@ object Dfp extends DfpService {
     campaignName: String,
     clientName: String,
     service: LineItemServiceInterface,
-    orderIds: Seq[Long]
+    orderIds: Seq[Long],
+    lineItemIdsToIgnore: Seq[Long]
   ): Seq[LineItem] = {
 
     val fetches: Stream[Seq[LineItem]] = {
@@ -89,10 +90,14 @@ object Dfp extends DfpService {
 
         def fetchByNameAndOrder(nameCondition: String, orderId: Long): Seq[LineItem] = {
           Logger.info(s"Fetching line items to suggest in order $orderId with condition [$nameCondition]")
+          val lineItemCondition = {
+            if (lineItemIdsToIgnore.isEmpty) ""
+            else s"AND NOT id IN (${lineItemIdsToIgnore.mkString(",")})"
+          }
           fetchLineItems(
             service,
             new StatementBuilder()
-            .where(s"orderId = :orderId AND ($nameCondition)")
+            .where(s"orderId = :orderId $lineItemCondition AND ($nameCondition)")
             .withBindVariableValue("orderId", orderId)
           )
         }

--- a/cloudformation/dynamoDb.json
+++ b/cloudformation/dynamoDb.json
@@ -197,6 +197,46 @@
         }
       },
       "DeletionPolicy": "Retain"
+    },
+    "TrafficDriverRejectDBTable": {
+      "Type": "AWS::DynamoDB::Table",
+      "Properties": {
+        "AttributeDefinitions": [
+          {
+            "AttributeName": "campaignId",
+            "AttributeType": "S"
+          }, {
+            "AttributeName": "lineItemId",
+            "AttributeType": "N"
+          }
+        ],
+        "KeySchema": [
+          {
+            "AttributeName": "campaignId",
+            "KeyType": "HASH"
+          },{
+            "AttributeName": "lineItemId",
+            "KeyType": "RANGE"
+          }
+        ],
+        "ProvisionedThroughput": {
+          "ReadCapacityUnits": "1",
+          "WriteCapacityUnits": "1"
+        },
+        "TableName": {
+          "Fn::Join": [
+            "-",
+            [
+              "campaign-central",
+              {
+                "Ref": "Stage"
+              },
+              "drivers-rejected"
+            ]
+          ]
+        }
+      },
+      "DeletionPolicy": "Retain"
     }
   }
 }

--- a/cloudformation/dynamoDb.json
+++ b/cloudformation/dynamoDb.json
@@ -220,8 +220,8 @@
           }
         ],
         "ProvisionedThroughput": {
-          "ReadCapacityUnits": "1",
-          "WriteCapacityUnits": "1"
+          "ReadCapacityUnits": "5",
+          "WriteCapacityUnits": "5"
         },
         "TableName": {
           "Fn::Join": [

--- a/conf/routes
+++ b/conf/routes
@@ -15,25 +15,26 @@ GET            /reauth            controllers.App.reauth
 
 #Campaign Api
 
-GET /api/campaigns                        controllers.CampaignApi.getAllCampaigns
-GET /api/campaigns/analytics              controllers.CampaignApi.getAnalyticsSummary
-GET /api/campaigns/:id                    controllers.CampaignApi.getCampaign(id: String)
-PUT /api/campaigns/:id                    controllers.CampaignApi.updateCampaign(id: String)
-DELETE /api/campaigns/:id                 controllers.CampaignApi.deleteCampaign(id: String)
-GET /api/campaigns/:id/pageViews          controllers.CampaignApi.getCampaignPageViews(id: String)
-GET /api/campaigns/:id/dailyUniques       controllers.CampaignApi.getCampaignDailyUniqueUsers(id: String)
-GET /api/campaigns/:id/targetsReport      controllers.CampaignApi.getCampaignTargetsReport(id: String)
-GET /api/campaigns/:id/content            controllers.CampaignApi.getCampaignContent(id: String)
-GET /api/campaigns/:id/notes              controllers.CampaignApi.getCampaignNotes(id: String)
-POST /api/campaigns/:id/notes             controllers.CampaignApi.addCampaignNote(id: String)
-PUT /api/campaigns/:id/note/:date         controllers.CampaignApi.updateCampaignNote(id: String, date: String)
-POST /api/campaigns/import                controllers.CampaignApi.importFromTag()
-POST /api/campaigns/:id/refreshFromCAPI   controllers.CampaignApi.refreshCampaignFromCAPI(id: String)
-GET /api/campaigns/:id/drivers            controllers.CampaignApi.getCampaignTrafficDrivers(id: String)
-GET /api/campaigns/:id/suggest-drivers    controllers.CampaignApi.getSuggestedCampaignTrafficDrivers(id: String)
-PUT /api/campaigns/:id/driver/:driverId   controllers.CampaignApi.acceptSuggestedCampaignTrafficDriver(id: String, driverId: Long)
-GET /api/campaigns/:id/driverstats        controllers.CampaignApi.getCampaignTrafficDriverStats(id: String)
-GET /api/campaigns/:id/ctastats           controllers.CampaignApi.getCampaignCtaStats(id: String)
+GET /api/campaigns                          controllers.CampaignApi.getAllCampaigns
+GET /api/campaigns/analytics                controllers.CampaignApi.getAnalyticsSummary
+GET /api/campaigns/:id                      controllers.CampaignApi.getCampaign(id: String)
+PUT /api/campaigns/:id                      controllers.CampaignApi.updateCampaign(id: String)
+DELETE /api/campaigns/:id                   controllers.CampaignApi.deleteCampaign(id: String)
+GET /api/campaigns/:id/pageViews            controllers.CampaignApi.getCampaignPageViews(id: String)
+GET /api/campaigns/:id/dailyUniques         controllers.CampaignApi.getCampaignDailyUniqueUsers(id: String)
+GET /api/campaigns/:id/targetsReport        controllers.CampaignApi.getCampaignTargetsReport(id: String)
+GET /api/campaigns/:id/content              controllers.CampaignApi.getCampaignContent(id: String)
+GET /api/campaigns/:id/notes                controllers.CampaignApi.getCampaignNotes(id: String)
+POST /api/campaigns/:id/notes               controllers.CampaignApi.addCampaignNote(id: String)
+PUT /api/campaigns/:id/note/:date           controllers.CampaignApi.updateCampaignNote(id: String, date: String)
+POST /api/campaigns/import                  controllers.CampaignApi.importFromTag()
+POST /api/campaigns/:id/refreshFromCAPI     controllers.CampaignApi.refreshCampaignFromCAPI(id: String)
+GET /api/campaigns/:id/drivers              controllers.CampaignApi.getCampaignTrafficDrivers(id: String)
+GET /api/campaigns/:id/suggest-drivers      controllers.CampaignApi.getSuggestedCampaignTrafficDrivers(id: String)
+PUT /api/campaigns/:id/driver/:driverId     controllers.CampaignApi.acceptSuggestedCampaignTrafficDriver(id: String, driverId: Long)
+PUT /api/campaigns/:id/not-driver/:driverId controllers.CampaignApi.rejectSuggestedCampaignTrafficDriver(id: String, driverId: Long)
+GET /api/campaigns/:id/driverstats          controllers.CampaignApi.getCampaignTrafficDriverStats(id: String)
+GET /api/campaigns/:id/ctastats             controllers.CampaignApi.getCampaignCtaStats(id: String)
 
 
 #Clients Api

--- a/public/actions/CampaignActions/RejectSuggestedCampaignTrafficDriver.js
+++ b/public/actions/CampaignActions/RejectSuggestedCampaignTrafficDriver.js
@@ -1,0 +1,37 @@
+import {rejectSuggestedCampaignTrafficDriver as rejectSuggestedCampaignTrafficDriverApi} from "../../services/CampaignsApi";
+
+function requestReject(campaignId, trafficDriverId) {
+  return {
+    type: 'CAMPAIGN_DRIVER_REJECT_REQUEST',
+    campaignId: campaignId,
+    trafficDriverId: trafficDriverId,
+    receivedAt: Date.now()
+  };
+}
+
+function receiveReject() {
+  return {
+    type: 'CAMPAIGN_DRIVER_REJECT_RECEIVE',
+    receivedAt: Date.now()
+  };
+}
+
+function errorRejecting(error) {
+  return {
+    type: 'SHOW_ERROR',
+    message: 'Could not reject suggested campaign traffic driver',
+    error: error,
+    receivedAt: Date.now()
+  };
+}
+
+export function rejectSuggestedCampaignTrafficDriver(campaignId, trafficDriverId) {
+  return dispatch => {
+    dispatch(requestReject(campaignId, trafficDriverId));
+    return rejectSuggestedCampaignTrafficDriverApi(campaignId, trafficDriverId)
+      .catch(error => dispatch(errorRejecting(error)))
+      .then(res => {
+        dispatch(receiveReject(res));
+      });
+  };
+}

--- a/public/components/CampaignInformationEdit/CampaignTrafficDriverSuggestions.js
+++ b/public/components/CampaignInformationEdit/CampaignTrafficDriverSuggestions.js
@@ -4,18 +4,13 @@ import {bindActionCreators} from "redux";
 
 class CampaignTrafficDriverSuggestions extends React.Component {
 
-  rejectSuggestion = (trafficDriverId) => {
-    console.log('*** Rejecting traffic driver ' + trafficDriverId + ' for campaign ' + this.props.campaignId);
-    alert("Does nothing yet!")
-  };
-
   renderSuggestion = (trafficDriver) => {
     return (
       <div key={trafficDriver.id} className="campaign-suggestion-list__row">
         <span><i className="i-dfp"/></span>
         <span><a href={trafficDriver.url} target="_blank">{trafficDriver.name} ({trafficDriver.id})</a></span>
         <span className="campaign-suggestion-list__button"><button  onClick={() => this.props.acceptSuggestion(trafficDriver.id)}>Yes</button></span>
-        <span className="campaign-suggestion-list__button"><button onClick={() => this.rejectSuggestion(trafficDriver.id)}>No</button></span>
+        <span className="campaign-suggestion-list__button"><button onClick={() => this.props.rejectSuggestion(trafficDriver.id)}>No</button></span>
       </div>
     );
   };

--- a/public/components/CampaignInformationEdit/CampaignTrafficDriversAndSuggestions.js
+++ b/public/components/CampaignInformationEdit/CampaignTrafficDriversAndSuggestions.js
@@ -6,6 +6,7 @@ import {bindActionCreators} from "redux";
 import * as getCampaignTrafficDrivers from "../../actions/CampaignActions/getCampaignTrafficDrivers";
 import * as getCampaignTrafficDriverSuggestions from "../../actions/CampaignActions/getCampaignTrafficDriverSuggestions";
 import * as acceptSuggestedCampaignTrafficDriver from "../../actions/CampaignActions/AcceptSuggestedCampaignTrafficDriver";
+import * as rejectSuggestedCampaignTrafficDriver from "../../actions/CampaignActions/RejectSuggestedCampaignTrafficDriver";
 
 class CampaignTrafficDriversAndSuggestions extends React.Component {
 
@@ -15,14 +16,25 @@ class CampaignTrafficDriversAndSuggestions extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if ((nextProps.campaign.id !== this.props.campaign.id) || (nextProps.campaignTrafficDriversDirty && !this.props.campaignTrafficDriversDirty)) {
+    const campaignChanged = nextProps.campaign.id !== this.props.campaign.id;
+    const driversNeedRefresh = nextProps.campaignTrafficDriversDirty && !this.props.campaignTrafficDriversDirty;
+    const suggestionsNeedRefresh = nextProps.campaignTrafficDriverSuggestionsDirty && !this.props.campaignTrafficDriverSuggestionsDirty;
+
+    if (campaignChanged || driversNeedRefresh) {
       this.props.campaignTrafficDriverActions.getCampaignTrafficDrivers(nextProps.campaign.id);
+    }
+
+    if (campaignChanged || driversNeedRefresh || suggestionsNeedRefresh) {
       this.props.campaignTrafficDriverSuggestionActions.getCampaignTrafficDriverSuggestions(nextProps.campaign.id);
     }
   }
 
   acceptSuggestion = (trafficDriverId) => {
     this.props.campaignTrafficDriverSuggestionActions.acceptSuggestedCampaignTrafficDriver(this.props.campaign.id, trafficDriverId);
+  };
+
+  rejectSuggestion = (trafficDriverId) => {
+    this.props.campaignTrafficDriverSuggestionActions.rejectSuggestedCampaignTrafficDriver(this.props.campaign.id, trafficDriverId);
   };
 
   render() {
@@ -34,7 +46,8 @@ class CampaignTrafficDriversAndSuggestions extends React.Component {
           <CampaignTrafficDrivers campaignTrafficDrivers={this.props.campaignTrafficDrivers}/>
           <CampaignTrafficDriverSuggestions campaignId={this.props.campaign.id}
                                             campaignTrafficDriverSuggestions={this.props.campaignTrafficDriverSuggestions}
-                                            acceptSuggestion={(trafficDriverId) => this.acceptSuggestion(trafficDriverId)}/>
+                                            acceptSuggestion={(trafficDriverId) => this.acceptSuggestion(trafficDriverId)}
+                                            rejectSuggestion={(trafficDriverId) => this.rejectSuggestion(trafficDriverId)}/>
         </div>
       </div>
     );
@@ -43,16 +56,21 @@ class CampaignTrafficDriversAndSuggestions extends React.Component {
 
 function mapStateToProps(state) {
   return {
-    campaignTrafficDrivers:           state.campaignTrafficDrivers,
+    campaignTrafficDrivers: state.campaignTrafficDrivers,
     campaignTrafficDriverSuggestions: state.campaignTrafficDriverSuggestions,
-    campaignTrafficDriversDirty:      state.campaignTrafficDriversDirty
+    campaignTrafficDriversDirty: state.campaignTrafficDriversDirty,
+    campaignTrafficDriverSuggestionsDirty: state.campaignTrafficDriverSuggestionsDirty
   };
 }
 
 function mapDispatchToProps(dispatch) {
   return {
     campaignTrafficDriverActions:           bindActionCreators(Object.assign({}, getCampaignTrafficDrivers), dispatch),
-    campaignTrafficDriverSuggestionActions: bindActionCreators(Object.assign({}, getCampaignTrafficDriverSuggestions, acceptSuggestedCampaignTrafficDriver), dispatch)
+    campaignTrafficDriverSuggestionActions: bindActionCreators(Object.assign({},
+      getCampaignTrafficDriverSuggestions,
+      acceptSuggestedCampaignTrafficDriver,
+      rejectSuggestedCampaignTrafficDriver
+    ), dispatch)
   };
 }
 

--- a/public/reducers/campaignTrafficDriverSuggestionsDirtyReducer.js
+++ b/public/reducers/campaignTrafficDriverSuggestionsDirtyReducer.js
@@ -1,0 +1,13 @@
+export default function campaignTrafficDriverSuggestionsDirty(state = false, action) {
+  switch (action.type) {
+
+    case 'TRAFFIC_DRIVER_SUGGESTIONS_GET_RECEIVE':
+      return false;
+
+    case 'CAMPAIGN_DRIVER_REJECT_RECEIVE':
+      return true;
+
+    default:
+      return state;
+  }
+}

--- a/public/reducers/campaignTrafficDriversDirtyReducer.js
+++ b/public/reducers/campaignTrafficDriversDirtyReducer.js
@@ -1,7 +1,7 @@
 export default function campaignTrafficDriversDirty(state = false, action) {
   switch (action.type) {
 
-    case 'TRAFFIC_DRIVER_SUGGESTIONS_GET_RECEIVE':
+    case 'TRAFFIC_DRIVERS_GET_RECEIVE':
       return false;
 
     case 'CAMPAIGN_DRIVER_ACCEPT_RECEIVE':

--- a/public/reducers/rootReducer.js
+++ b/public/reducers/rootReducer.js
@@ -11,8 +11,9 @@ import clients from './clientsReducer';
 import client from './clientReducer';
 import campaignContent from './campaignContentReducer';
 import campaignTrafficDrivers from './campaignTrafficDriverReducer';
-import campaignTrafficDriverSuggestions from './campaignTrafficDriverSuggestionsReducer';
 import campaignTrafficDriversDirty from './campaignTrafficDriversDirtyReducer';
+import campaignTrafficDriverSuggestions from './campaignTrafficDriverSuggestionsReducer';
+import campaignTrafficDriverSuggestionsDirty from './campaignTrafficDriverSuggestionsDirtyReducer';
 import campaignTrafficDriverStats from './campaignTrafficDriverStatsReducer';
 import campaignNotes from './campaignNotesReducer';
 import campaignSort from './campaignSortReducer';
@@ -31,8 +32,9 @@ export default combineReducers({
   client,
   campaignContent,
   campaignTrafficDrivers,
-  campaignTrafficDriverSuggestions,
   campaignTrafficDriversDirty,
+  campaignTrafficDriverSuggestions,
+  campaignTrafficDriverSuggestionsDirty,
   campaignTrafficDriverStats,
   campaignNotes,
   campaignSort,

--- a/public/services/CampaignsApi.js
+++ b/public/services/CampaignsApi.js
@@ -98,6 +98,15 @@ export function acceptSuggestedCampaignTrafficDriver(campaignId, trafficDriverId
   });
 }
 
+export function rejectSuggestedCampaignTrafficDriver(campaignId, trafficDriverId) {
+  return AuthedReqwest({
+    url: '/api/campaigns/' + campaignId + '/not-driver/' + trafficDriverId,
+    contentType: 'application/json',
+    data: {null},
+    method: 'put'
+  });
+}
+
 export function fetchCampaignTrafficDriverStats(id) {
   return AuthedReqwest({
     url: '/api/campaigns/' + id + '/driverstats',


### PR DESCRIPTION
This change keeps a persistent store of rejected traffic driver suggestions so that they don't keep coming up.

/cc @guardian/commercial-dev 