### PR TITLE
Sw import finished campaign

### DIFF
--- a/app/model/reports/CampaignPageViewsReport.scala
+++ b/app/model/reports/CampaignPageViewsReport.scala
@@ -126,7 +126,7 @@ object CampaignPageViewsReport {
       startDate <- campaign.startDate
     ) yield {
       val dailyReports = DateBasedReport.calculateDatesToFetch(startDate, campaign.endDate).map{ dt =>
-        Thread.sleep(1000) // try to avoid rate limiting
+        Thread.sleep(3000) // try to avoid rate limiting
         loadCampaignPageViewsForDay(campaign, dt)
       }
 

--- a/app/model/reports/DailyUniqueUsersReport.scala
+++ b/app/model/reports/DailyUniqueUsersReport.scala
@@ -87,7 +87,7 @@ object DailyUniqueUsersReport {
       startDate <- campaign.startDate
     ) yield {
       val dailyReports = DateBasedReport.calculateDatesToFetch(startDate, campaign.endDate).map{ dt =>
-        Thread.sleep(1000) // try to avoid rate limiting
+        Thread.sleep(3000) // try to avoid rate limiting
         loadCampaignDailyUniquesForDay(campaign, dt)
       }
 


### PR DESCRIPTION
Uses data from the sponsorship object not the CAPI data to derive sponsor name. This means that expired campaigns should be imported correctly.