### PR TITLE
update DFP dependency version

### DIFF
--- a/app/model/TrafficDriver.scala
+++ b/app/model/TrafficDriver.scala
@@ -2,7 +2,7 @@ package model
 
 import java.time.LocalDate
 
-import com.google.api.ads.dfp.axis.v201608.{DateTime, LineItem}
+import com.google.api.ads.dfp.axis.v201705.{DateTime, LineItem}
 import play.api.Logger
 import play.api.libs.json.{Json, Writes}
 import repositories._

--- a/app/services/Dfp.scala
+++ b/app/services/Dfp.scala
@@ -3,13 +3,13 @@ package services
 import com.google.api.ads.common.lib.auth.OfflineCredentials
 import com.google.api.ads.common.lib.auth.OfflineCredentials.Api._
 import com.google.api.ads.dfp.axis.factory.DfpServices
-import com.google.api.ads.dfp.axis.utils.v201608.StatementBuilder.SUGGESTED_PAGE_LIMIT
-import com.google.api.ads.dfp.axis.utils.v201608.{ReportDownloader, StatementBuilder}
-import com.google.api.ads.dfp.axis.v201608.Column._
-import com.google.api.ads.dfp.axis.v201608.DateRangeType.REACH_LIFETIME
-import com.google.api.ads.dfp.axis.v201608.Dimension._
-import com.google.api.ads.dfp.axis.v201608.ExportFormat._
-import com.google.api.ads.dfp.axis.v201608.{ReportDownloadOptions, ReportJob, ReportQuery, ReportServiceInterface, _}
+import com.google.api.ads.dfp.axis.utils.v201705.StatementBuilder.SUGGESTED_PAGE_LIMIT
+import com.google.api.ads.dfp.axis.utils.v201705.{ReportDownloader, StatementBuilder}
+import com.google.api.ads.dfp.axis.v201705.Column._
+import com.google.api.ads.dfp.axis.v201705.DateRangeType.REACH_LIFETIME
+import com.google.api.ads.dfp.axis.v201705.Dimension._
+import com.google.api.ads.dfp.axis.v201705.ExportFormat._
+import com.google.api.ads.dfp.axis.v201705.{ReportDownloadOptions, ReportJob, ReportQuery, ReportServiceInterface, _}
 import com.google.api.ads.dfp.lib.client.DfpSession
 import play.api.Logger
 import services.Config.conf._

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ lazy val dependencies = Seq(
   "com.gu" % "kinesis-logback-appender" % "1.3.0",
   "org.slf4j" % "slf4j-api" % slf4jVersion,
   "org.slf4j" % "jcl-over-slf4j" % slf4jVersion,
-  "com.google.api-ads" % "dfp-axis" % "2.22.0",
+  "com.google.api-ads" % "dfp-axis" % "3.5.0",
   "com.google.guava" % "guava" % "20.0",
   "org.scalatest" %% "scalatest" % "3.0.1" % Test
 )


### PR DESCRIPTION
Update DFP dependency to latest version; as v201608 is being deprecated as per http://googleadsdeveloper.blogspot.co.uk/2017/07/sunset-of-dfp-api-v201608.html
CC @guardian/commercial-dev