### PR TITLE
Fix JS SyntaxError so that webpack stops failing

### DIFF
--- a/public/services/CampaignsApi.js
+++ b/public/services/CampaignsApi.js
@@ -101,7 +101,7 @@ export function acceptSuggestedCampaignTrafficDriver(campaignId, trafficDriverId
   return AuthedReqwest({
     url: '/api/campaigns/' + campaignId + '/driver/' + trafficDriverId,
     contentType: 'application/json',
-    data: {null},
+    data: {},
     method: 'put'
   });
 }
@@ -110,7 +110,7 @@ export function rejectSuggestedCampaignTrafficDriver(campaignId, trafficDriverId
   return AuthedReqwest({
     url: '/api/campaigns/' + campaignId + '/not-driver/' + trafficDriverId,
     contentType: 'application/json',
-    data: {null},
+    data: {},
     method: 'put'
   });
 }


### PR DESCRIPTION
Webpack was unhappy:

<img width="572" alt="picture 836" src="https://user-images.githubusercontent.com/8607683/28164245-763167f2-67c6-11e7-82d1-0aee62055938.png">

This PR removes the `null`s that were making Webpack throw syntax errors.

Campaign Central will run again! 🎉