### PR TITLE
Ensure Webpack throws a non-zero exit code... Bonus: add emoji 😎 

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "Tool for managing campaigns",
   "scripts": {
-    "build": "webpack -p ./public/app.js ./public/build/app.js --config ./public/build_config/webpack.prod.conf.js",
+    "build": "webpack -p ./public/app.js ./public/build/app.js --config ./public/build_config/webpack.prod.conf.js --bail",
     "build-dev": "webpack ./public/app.js ./public/build/app.js --config ./public/build_config/webpack.dev.conf.js --watch",
     "build-icons": "svg-sprite -w 12 -h 12 -v true --view-bust false --view-prefix .i-%s --view-dest . --vs ./public/images/icons.svg --vscss true --view-render-scss-template ./public/images/icons/scssTemplate.scss --view-render-scss-dest ./public/styles/_icons.scss  ./public/images/icons/*.svg",
     "client-dev": "node ./public/devserver.js"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 
-printf "\n\rSetting up Campaign Central Client Side dependancies... \n\r\n\r"
-printf "\n\rInstalling NPM packages... \n\r\n\r"
+printf "\n\r 🙏  Setting up Campaign Central Client Side dependencies... \n\r\n\r"
+printf "\n\r 📦  Installing NPM packages... \n\r\n\r"
 
 npm install
 
-printf "\n\Compiling Javascript... \n\r\n\r"
+printf "\n\r ⏳  Compiling JavaScript... \n\r\n\r"
 
 npm run build
 
-printf "\n\Building Icons... \n\r\n\r"
+printf "\n\r 🛠  Building Icons... \n\r\n\r"
 
 npm run build-icons
 
-printf "\n\rDone.\n\r\n\r"
+printf "\n\r 👍  Done.\n\r\n\r"


### PR DESCRIPTION
## Webpack Fix

- add the `--bail` flag to the Webpack command

We recently had an issue that caused `sh scripts/setup.sh` to explode, however the tests would still pass on CircleCI.

This appears to be the most elegant way to ensure that Webpack will throw a non-zero exit code, and cause CircleCI to fail if there are errors encountered. More information here: https://github.com/webpack/webpack/issues/708

If I use this flag, add back the issue from #92, and start opening a PR, I will now see the tests failing on CircleCI:

<img width="1083" alt="picture 838" src="https://user-images.githubusercontent.com/8607683/28178630-115dfb70-67f7-11e7-9cc4-9e0a34d17958.png">

Also, you should now see `Exit status 1` on the CLI accordingly if something breaks:

<img width="634" alt="picture 837" src="https://user-images.githubusercontent.com/8607683/28179406-b5eea96c-67f9-11e7-9fac-4f08cc26c80a.png">




I am not adding the flag to build-dev, since we probably don't want to bail out of watch mode if a developer is hacking around on their local version.

## Spelling and Emoji

- Fixing slight spelling and casing issue in setup.sh 

- I like to meddle... so bonus emoji! Everything is better with emoji ❤️✌️

Running `sh scripts/setup.sh` will now print something like this to the terminal:

<img width="782" alt="picture 839" src="https://user-images.githubusercontent.com/8607683/28178326-01093c4a-67f6-11e7-87bb-1aa48003c7da.png">
