### PR TITLE
Add table for on-platform referrals

### DIFF
--- a/cloudformation/dynamoDb.yaml
+++ b/cloudformation/dynamoDb.yaml
@@ -204,24 +204,18 @@ Resources:
         AttributeType: S
       - AttributeName: platformUrlComponent
         AttributeType: S
-      - AttributeName: clicks
-        AttributeType: N
-      - AttributeName: firstReferral
-        AttributeType: S
-      - AttributeName: lastReferral
-        AttributeType: S
       KeySchema:
       - AttributeName: campaignId
         KeyType: HASH
       - AttributeName: platformUrlComponent
         KeyType: RANGE
       ProvisionedThroughput:
-        ReadCapacityUnits: '10'
-        WriteCapacityUnits: '10'
+        ReadCapacityUnits: '5'
+        WriteCapacityUnits: '5'
       TableName:
         Fn::Join:
         - "-"
         - - campaign-central
           - Ref: Stage
-          - campaign-referrals
+          - referrals
     DeletionPolicy: Retain

--- a/cloudformation/dynamoDb.yaml
+++ b/cloudformation/dynamoDb.yaml
@@ -195,3 +195,33 @@ Resources:
           - Ref: Stage
           - campaign-page-views
     DeletionPolicy: Retain
+
+  CampaignReferralsDBTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      AttributeDefinitions:
+      - AttributeName: campaignId
+        AttributeType: S
+      - AttributeName: platformUrlComponent
+        AttributeType: S
+      - AttributeName: clicks
+        AttributeType: N
+      - AttributeName: firstReferral
+        AttributeType: S
+      - AttributeName: lastReferral
+        AttributeType: S
+      KeySchema:
+      - AttributeName: campaignId
+        KeyType: HASH
+      - AttributeName: platformUrlComponent
+        KeyType: RANGE
+      ProvisionedThroughput:
+        ReadCapacityUnits: '10'
+        WriteCapacityUnits: '10'
+      TableName:
+        Fn::Join:
+        - "-"
+        - - campaign-central
+          - Ref: Stage
+          - campaign-referrals
+    DeletionPolicy: Retain


### PR DESCRIPTION
This is to take results from job https://github.com/guardian/ophan-data-lake/pull/1071

The `platformUrlComponent` column takes the 3 fields `platform`, `URL` and `component` rammed together into a single pipe-separated string to give a unique value per campaign.
