### PR TITLE
Add table to store latest analytics data per campaign.

### DIFF
--- a/cloudformation/dynamoDb.yaml
+++ b/cloudformation/dynamoDb.yaml
@@ -219,3 +219,24 @@ Resources:
           - Ref: Stage
           - referrals
     DeletionPolicy: Retain
+
+  CampaignAnalyticsLatestDBTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      AttributeDefinitions:
+      - AttributeName: campaignId
+        AttributeType: S
+      KeySchema:
+      - AttributeName: campaignId
+        KeyType: HASH
+      ProvisionedThroughput:
+        ReadCapacityUnits: '5'
+        WriteCapacityUnits: '5'
+      TableName:
+        Fn::Join:
+        - "-"
+        - - campaign-central
+          - Ref: Stage
+          - analytics
+          - latest
+    DeletionPolicy: Retain


### PR DESCRIPTION
This table will store the latest number of uniques and pageviews for a campaign. The data lake job will overwrite this data per campaign when it runs every night. This greatly simplifies our ability to retrieve this information from Campaign Central and allows us to make use of an existing job that is already running.