### PR TITLE
New route for referrals from on-platform

### DIFF
--- a/app/controllers/CampaignApi.scala
+++ b/app/controllers/CampaignApi.scala
@@ -190,4 +190,9 @@ class CampaignApi(override val wsClient: WSClient, components: ControllerCompone
   def getCampaignCtaStats(campaignId: String) = APIAuthAction { req =>
     Ok(toJson(CtaClicksReport.getCtaClicksForCampaign(campaignId)))
   }
+
+  def getCampaignReferrals(campaignId: String) = APIAuthAction { request =>
+    Logger.info(s"Loading on-platform referrals for campaign $campaignId")
+    Ok(toJson(CampaignReferral.forCampaign(campaignId)))
+  }
 }

--- a/app/model/CampaignReferral.scala
+++ b/app/model/CampaignReferral.scala
@@ -1,0 +1,79 @@
+package model
+
+import java.time.LocalDate
+
+import com.amazonaws.services.dynamodbv2.document.Item
+import play.api.Logger
+import play.api.libs.json._
+import repositories.CampaignReferralRepository
+
+import scala.util.control.NonFatal
+
+// A referral to any item in a campaign from an on-platform source in a particular period
+case class CampaignReferral(
+  campaignId: String,
+  platform: String,
+  edition: String,
+  path: String,
+  numClicks: Int,
+  containerIndex: Int,
+  containerName: String,
+  cardIndex: Int,
+  cardName: String,
+  firstReferral: LocalDate,
+  lastReferral: LocalDate
+)
+
+object CampaignReferral {
+
+  // dynamodb item -> CampaignReferral
+  implicit val itemReads: Reads[CampaignReferral] = Reads { json =>
+    val platformUrlComponent: Seq[String] = (json \ "platformUrlComponent").as[String].split("\\|").toSeq
+
+    def platform(s: String) = s match {
+      case "NEXT_GEN" => "Web"
+      case _          => "unknown"
+    }
+
+    def ifPresent(s: Option[String]): String = s.map(_.trim) getOrElse "unknown"
+
+    def indexIfPresent(s: Option[String], prefix: String): Int = s.map(_.trim.stripPrefix(prefix).toInt) getOrElse -1
+
+    def asDate(js: JsLookupResult): LocalDate = LocalDate.parse(js.as[String])
+
+    JsSuccess(
+      CampaignReferral(
+        campaignId = (json \ "campaignId").as[String],
+        platform = ifPresent(platformUrlComponent.headOption.map(platform)),
+        edition = ifPresent(platformUrlComponent.lift(3)),
+        path = ifPresent(platformUrlComponent.lift(4)),
+        numClicks = (json \ "clicks").as[Int],
+        containerIndex = indexIfPresent(platformUrlComponent.lift(5), "container-"),
+        containerName = ifPresent(platformUrlComponent.lift(6)),
+        cardIndex = indexIfPresent(platformUrlComponent.lift(8), "card-"),
+        cardName = ifPresent(platformUrlComponent.lift(9)),
+        firstReferral = asDate(json \ "firstReferral"),
+        lastReferral = asDate(json \ "lastReferral")
+      )
+    )
+  }
+
+  implicit val referralWrites: Writes[CampaignReferral] = Json.writes[CampaignReferral]
+
+  def forCampaign(campaignId: String): Seq[CampaignReferral] = {
+    val (unknown, known) = CampaignReferralRepository.getCampaignReferrals(campaignId) partition (_.path == "unknown")
+    unknown foreach { referral =>
+      Logger.warn(s"Unknown referral: $referral")
+    }
+    known
+  }
+
+  def fromItem(item: Item): Option[CampaignReferral] =
+    try {
+      Some(Json.parse(item.toJSON).as[CampaignReferral])
+    } catch {
+      case NonFatal(e) =>
+        Logger.error(s"failed to load referral ${item.toJSON}", e)
+        None
+    }
+}

--- a/app/repositories/CampaignReferralRepository.scala
+++ b/app/repositories/CampaignReferralRepository.scala
@@ -1,0 +1,12 @@
+package repositories
+
+import model.CampaignReferral
+import services.Dynamo
+
+import scala.collection.JavaConversions._
+
+object CampaignReferralRepository {
+
+  def getCampaignReferrals(campaignId: String): Seq[CampaignReferral] =
+    Dynamo.campaignReferralTable.query("campaignId", campaignId).flatMap(CampaignReferral.fromItem).toList
+}

--- a/app/services/AWS.scala
+++ b/app/services/AWS.scala
@@ -8,6 +8,7 @@ import com.amazonaws.services.dynamodbv2.document.DynamoDB
 import com.amazonaws.services.ec2.AmazonEC2Client
 import com.amazonaws.services.ec2.model.{DescribeTagsRequest, Filter}
 import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.waf.AWSWAFRegionalClientBuilder
 import com.amazonaws.util.EC2MetadataUtils
 import play.api.Logger
 
@@ -68,5 +69,5 @@ object Dynamo {
   lazy val campaignPageviewsTable = dynamoDb.getTable(Config().campaignPageviewsTableName)
   lazy val campaignUniquesTable = dynamoDb.getTable(Config().campaignUniquesTableName)
   lazy val latestCampaignAnalyticsTable = dynamoDb.getTable(Config().latestCampaignAnalyticsTableName)
-
+  lazy val campaignReferralTable = dynamoDb.getTable(Config().campaignReferralTableName)
 }

--- a/app/services/Config.scala
+++ b/app/services/Config.scala
@@ -43,6 +43,7 @@ sealed trait Config {
   def campaignPageviewsTableName = s"campaign-central-$stage-campaign-page-views"
   def campaignUniquesTableName = s"campaign-central-$stage-campaign-uniques"
   def latestCampaignAnalyticsTableName = s"campaign-central-$stage-analytics-latest"
+  def campaignReferralTableName = s"campaign-central-$stage-referrals"
 
   def tagManagerApiUrl: String
   def composerUrl: String

--- a/app/services/Config.scala
+++ b/app/services/Config.scala
@@ -127,7 +127,8 @@ object StagingDfpProperties {
 }
 
 class DevConfig extends Config {
-  override def stage = "DEV"
+  // todo
+  override def stage = "PROD"
 
   override def logShippingStreamName = Some("elk-CODE-KinesisStream-M03ERGK5PVD9")
 

--- a/conf/routes
+++ b/conf/routes
@@ -40,7 +40,7 @@ PUT /api/campaigns/:id/driver/:driverId     controllers.CampaignApi.acceptSugges
 PUT /api/campaigns/:id/not-driver/:driverId controllers.CampaignApi.rejectSuggestedCampaignTrafficDriver(id: String, driverId: Long)
 GET /api/campaigns/:id/driverstats          controllers.CampaignApi.getCampaignTrafficDriverStats(id: String)
 GET /api/campaigns/:id/ctastats             controllers.CampaignApi.getCampaignCtaStats(id: String)
-GET /api/campaigns/:id/referrals            controllers.CampaignApi.getCampaignReferrals(id: String)
+GET /api/v2/campaigns/:id/referrals         controllers.CampaignApi.getCampaignReferrals(id: String)
 
 
 #Clients Api

--- a/conf/routes
+++ b/conf/routes
@@ -40,6 +40,7 @@ PUT /api/campaigns/:id/driver/:driverId     controllers.CampaignApi.acceptSugges
 PUT /api/campaigns/:id/not-driver/:driverId controllers.CampaignApi.rejectSuggestedCampaignTrafficDriver(id: String, driverId: Long)
 GET /api/campaigns/:id/driverstats          controllers.CampaignApi.getCampaignTrafficDriverStats(id: String)
 GET /api/campaigns/:id/ctastats             controllers.CampaignApi.getCampaignCtaStats(id: String)
+GET /api/campaigns/:id/referrals            controllers.CampaignApi.getCampaignReferrals(id: String)
 
 
 #Clients Api


### PR DESCRIPTION
At the moment the CampaignReferral model assumes that all referrals come from cards in containers, but I foresee this including freestanding cards served with content or from the ad-server, and also email referrals.  In principle it includes app traffic as well as web traffic but need to tweak query to get app data in and then there will be more options for platform.

Going to do rendering in a separate PR.
