### PR TITLE
Add on-platform referrals section to campaign page

### DIFF
--- a/app/repositories/CampaignReferralRepository.scala
+++ b/app/repositories/CampaignReferralRepository.scala
@@ -8,5 +8,10 @@ import scala.collection.JavaConversions._
 object CampaignReferralRepository {
 
   def getCampaignReferrals(campaignId: String): Seq[CampaignReferral] =
-    Dynamo.campaignReferralTable.query("campaignId", campaignId).flatMap(CampaignReferral.fromItem).toList
+    Dynamo.campaignReferralTable
+      .query("campaignId", campaignId)
+      .flatMap(CampaignReferral.fromItem)
+      .toList
+      .sortBy(_.numClicks)
+      .reverse
 }

--- a/public/actions/CampaignActions/getCampaignReferrals.js
+++ b/public/actions/CampaignActions/getCampaignReferrals.js
@@ -1,0 +1,37 @@
+import {fetchCampaignReferrals} from '../../services/CampaignsApi';
+
+function requestCampaignReferrals(id) {
+   return {
+        type:       'REFERRALS_GET_REQUEST',
+        id:         id,
+        receivedAt: Date.now()
+    };
+}
+
+function receiveCampaignReferrals(referrals) {
+    return {
+        type:              'REFERRALS_GET_RECEIVE',
+        campaignReferrals: referrals,
+        receivedAt:        Date.now()
+    };
+}
+
+function errorReceivingCampaignReferrals(error) {
+    return {
+        type:       'SHOW_ERROR',
+        message:    'Could not get referrals',
+        error:      error,
+        receivedAt: Date.now()
+    };
+}
+
+export function getCampaignReferrals(id) {
+    return dispatch => {
+      dispatch(requestCampaignReferrals(id));
+      return fetchCampaignReferrals(id)
+        .catch(error => dispatch(errorReceivingCampaignReferrals(error)))
+        .then(res => {
+          dispatch(receiveCampaignReferrals(res));
+        });
+    };
+}

--- a/public/components/Campaign/Campaign.js
+++ b/public/components/Campaign/Campaign.js
@@ -3,6 +3,7 @@ import {Link} from 'react-router';
 import CampaignEdit from '../CampaignInformationEdit/CampaignEdit';
 import CampaignAssets from '../CampaignInformationEdit/CampaignAssets';
 import CampaignAnalytics from '../CampaignAnalytics/CampaignAnalytics';
+import CampaignReferrals from '../CampaignAnalytics/Analytics/CampaignReferrals';
 import CampaignTrafficDriversAndSuggestions from '../CampaignInformationEdit/CampaignTrafficDriversAndSuggestions';
 
 class Campaign extends React.Component {
@@ -57,6 +58,7 @@ class Campaign extends React.Component {
           <CampaignAssets campaign={campaign}
                           getCampaign={this.props.campaignActions.getCampaign}
                           getCampaignContent={this.props.campaignActions.getCampaignContent} />
+          <CampaignReferrals campaign={campaign} />
           <CampaignTrafficDriversAndSuggestions campaign={campaign} />
         </div>
       </div>

--- a/public/components/CampaignAnalytics/Analytics/CampaignReferrals.js
+++ b/public/components/CampaignAnalytics/Analytics/CampaignReferrals.js
@@ -1,0 +1,104 @@
+import React from "react";
+import ProgressSpinner from "../../utils/ProgressSpinner";
+import {connect} from "react-redux";
+import {bindActionCreators} from "redux";
+import * as getCampaignReferrals from "../../../actions/CampaignActions/getCampaignReferrals";
+
+class CampaignReferrals extends React.Component {
+
+  componentWillMount() {
+    this.props.campaignReferralActions.getCampaignReferrals(this.props.campaign.id);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const campaignChanged = nextProps.campaign.id !== this.props.campaign.id;
+    if (campaignChanged) {
+      this.props.campaignReferralActions.getCampaignReferrals(nextProps.campaign.id);
+    }
+  }
+
+  renderReferral = (referral) => {
+
+    const dateFormat = (date) => {
+      return new Date(date).toLocaleDateString('en-GB', {day: '2-digit', month: 'short', year: 'numeric'})
+    };
+
+    return (
+      <div key={referral.hash} className="campaign-referral-list__item">
+        <div className="campaign-referral-list__row">
+          <div className="campaign-referral-list__platform">{referral.component.platform}</div>
+          <div className="campaign-referral-list__edition">{referral.component.edition}</div>
+          <div className="campaign-referral-list__path">{referral.component.path}</div>
+          <div className="campaign-referral-list__container">#{referral.component.containerIndex}: {referral.component.containerName}</div>
+          <div className="campaign-referral-list__card">#{referral.component.cardIndex}: {referral.component.cardName}</div>
+          <div className="campaign-referral-list__clicks">{referral.numClicks}</div>
+          <div className="campaign-referral-list__date">{dateFormat(referral.firstReferral)}</div>
+          <div className="campaign-referral-list__date">{dateFormat(referral.lastReferral)}</div>
+        </div>
+      </div>
+    );
+  };
+
+  render() {
+
+    if(!this.props.campaignReferrals) {
+      return (
+        <div className="campaign-info campaign-box">
+          <div className="campaign-box__header">Referrals from on-platform</div>
+          <div>*** Under construction ***</div>
+          <div className="campaign-box__body">
+            <ProgressSpinner/>
+          </div>
+        </div>
+      );
+    }
+
+    if(this.props.campaignReferrals.length > 0) {
+      return (
+        <div className="campaign-info campaign-box">
+          <div className="campaign-box__header">Referrals from on-platform</div>
+          <div>*** Under construction ***</div>
+          <div className="campaign-box__body">
+            <div className="campaign-referral-list campaign-assets__field__value">
+              <div className="campaign-referral-list__row">
+                <div className="campaign-referral-list__platform--header">Platform</div>
+                <div className="campaign-referral-list__edition--header">Edition</div>
+                <div className="campaign-referral-list__path--header">Path</div>
+                <div className="campaign-referral-list__container--header">Container</div>
+                <div className="campaign-referral-list__card--header">Card</div>
+                <div className="campaign-referral-list__clicks--header">Clicks</div>
+                <div className="campaign-referral-list__date--header">First referral</div>
+                <div className="campaign-referral-list__date--header">Last referral</div>
+              </div>
+              {this.props.campaignReferrals.map(this.renderReferral)}
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div className="campaign-info campaign-box">
+        <div className="campaign-box__header">Referrals from on-platform</div>
+        <div>*** Under construction ***</div>
+        <div className="campaign-box__body">
+          <span className="campaign-assets__field__value">No traffic has been referred from on-platform to this campaign yet.</span>
+        </div>
+      </div>
+    )
+  };
+}
+
+function mapStateToProps(state) {
+  return {
+    campaignReferrals: state.campaignReferrals
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    campaignReferralActions: bindActionCreators(Object.assign({}, getCampaignReferrals), dispatch)
+  };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(CampaignReferrals);

--- a/public/reducers/campaignReferralReducer.js
+++ b/public/reducers/campaignReferralReducer.js
@@ -1,0 +1,10 @@
+export default function campaignReferrals(state = null, action) {
+  switch (action.type) {
+
+    case 'REFERRALS_GET_RECEIVE':
+      return action.campaignReferrals || [];
+
+    default:
+      return state;
+  }
+}

--- a/public/reducers/rootReducer.js
+++ b/public/reducers/rootReducer.js
@@ -11,6 +11,7 @@ import campaignCtaStats from './campaignCtaStatsReducer';
 import clients from './clientsReducer';
 import client from './clientReducer';
 import campaignContent from './campaignContentReducer';
+import campaignReferrals from './campaignReferralReducer';
 import campaignTrafficDrivers from './campaignTrafficDriverReducer';
 import campaignTrafficDriversDirty from './campaignTrafficDriversDirtyReducer';
 import campaignTrafficDriverSuggestions from './campaignTrafficDriverSuggestionsReducer';
@@ -34,6 +35,7 @@ export default combineReducers({
   clients,
   client,
   campaignContent,
+  campaignReferrals,
   campaignTrafficDrivers,
   campaignTrafficDriversDirty,
   campaignTrafficDriverSuggestions,

--- a/public/services/CampaignsApi.js
+++ b/public/services/CampaignsApi.js
@@ -119,6 +119,13 @@ export function fetchCampaignTrafficDriverStats(id) {
   });
 }
 
+export function fetchCampaignReferrals(id) {
+  return AuthedReqwest({
+    url: '/api/v2/campaigns/' + id + '/referrals',
+    method: 'get'
+  });
+}
+
 export function fetchCampaignCtaStats(id) {
   return AuthedReqwest({
     url: '/api/campaigns/' + id + '/ctastats',

--- a/public/styles/components/campaign/_campaign-referrals.scss
+++ b/public/styles/components/campaign/_campaign-referrals.scss
@@ -1,0 +1,64 @@
+.campaign-referral-list__item {
+  border-bottom: 1px solid $c-grey-300;
+}
+
+.campaign-referral-list__row {
+  @extend %table__row;
+  border-bottom: none;
+}
+
+.campaign-referral-list__platform,
+.campaign-referral-list__edition,
+.campaign-referral-list__path,
+.campaign-referral-list__container,
+.campaign-referral-list__card,
+.campaign-referral-list__clicks,
+.campaign-referral-list__date {
+  @extend %table__cell;
+  white-space: normal;
+  position: relative;
+  overflow: auto;
+  border-bottom: none;
+
+  &--header {
+    @extend %table__cell;
+    background-color: $c-grey-200;
+    font-weight: bold;
+    white-space: normal;
+  }
+}
+
+.campaign-referral-list__platform,
+.campaign-referral-list__platform--header {
+  width: 10%;
+}
+
+.campaign-referral-list__edition,
+.campaign-referral-list__edition--header {
+  width: 10%;
+}
+
+.campaign-referral-list__path,
+.campaign-referral-list__path--header {
+  width: 20%;
+}
+
+.campaign-referral-list__container,
+.campaign-referral-list__container--header {
+  width: 15%;
+}
+
+.campaign-referral-list__card,
+.campaign-referral-list__card--header {
+  width: 15%;
+}
+
+.campaign-referral-list__clicks,
+.campaign-referral-list__clicks--header {
+  width: 10%;
+}
+
+.campaign-referral-list__date,
+.campaign-referral-list__date--header {
+  width: 10%;
+}

--- a/public/styles/components/campaign/_campaign.scss
+++ b/public/styles/components/campaign/_campaign.scss
@@ -83,3 +83,4 @@
 
   border: 1px solid $c-grey-300;;
 }
+

--- a/public/styles/main.scss
+++ b/public/styles/main.scss
@@ -16,6 +16,7 @@
 @import './components/campaign-assets/campaign-assets';
 @import './components/campaign-assets/campaign-content-list';
 @import './components/campaign-assets/campaign-cta-list';
+@import './components/campaign/campaign-referrals';
 @import './components/campaign-traffic-drivers/campaign-traffic-drivers';
 @import './components/campaign-info/campaign-info';
 @import './components/campaign-info/analytics/analytics';


### PR DESCRIPTION
This is the first attempt at a view of referrals:
![image](https://user-images.githubusercontent.com/1722550/29527149-e969c100-868f-11e7-91b2-034df7f5a048.png)


Needs quite a lot of work after this PR:
* Show the full dataset for the campaign (currently just a few days, and first and last referral dates are misleading)
* Show impression count and CTR as well as click count
* Aggregate data so not quite so fine-grained (probably don't need to separate out editions, but will find out what is useful)
* Add more platforms
* Add ad-served cards as well for comparison
* Add emails
