### PR TITLE
Add median attention time to campaign performance overview

### DIFF
--- a/app/model/LatestCampaignAnalytics.scala
+++ b/app/model/LatestCampaignAnalytics.scala
@@ -9,7 +9,9 @@ case class LatestCampaignAnalytics(
                                     uniquesFromMobile: Long,
                                     uniquesFromDesktop: Long,
                                     uniquesTarget: Long,
-                                    pageviews: Long)
+                                    pageviews: Long,
+                                    medianAttentionTimeSeconds: Option[Long],
+                                    medianAttentionTimeByPlatform: Option[Map[String, Long]])
 
 object LatestCampaignAnalytics {
   implicit val latestCampaignAnalyticsFormat: Format[LatestCampaignAnalytics] = Jsonx.formatCaseClass[LatestCampaignAnalytics]

--- a/app/model/LatestCampaignAnalyticsItem.scala
+++ b/app/model/LatestCampaignAnalyticsItem.scala
@@ -15,7 +15,9 @@ case class LatestCampaignAnalyticsItem(
                                  pageviewsByCountryCode: Map[String, Long],
                                  uniquesByCountryCode: Map[String, Long],
                                  pageviewsByDevice: Map[String, Long],
-                                 uniquesByDevice: Map[String, Long]
+                                 uniquesByDevice: Map[String, Long],
+                                 medianAttentionTimeSeconds: Option[Long],
+                                 medianAttentionTimeByPlatform: Option[Map[String, Long]]
                                ){
   def toItem = Item.fromJSON(Json.toJson(this).toString())
 }

--- a/app/services/CampaignService.scala
+++ b/app/services/CampaignService.scala
@@ -27,7 +27,7 @@ object CampaignService {
     } yield {
       val uniquesDeviceBreakdown = breakdownUniquesByMobileAndDesktop(latest.uniques, latest.uniquesByDevice)
       val uniquesTarget: Long = campaign.targets.getOrElse("uniques", 0)
-      LatestCampaignAnalytics(latest.campaignId, latest.uniques, uniquesDeviceBreakdown.mobile, uniquesDeviceBreakdown.desktop, uniquesTarget, latest.pageviews)
+      LatestCampaignAnalytics(latest.campaignId, latest.uniques, uniquesDeviceBreakdown.mobile, uniquesDeviceBreakdown.desktop, uniquesTarget, latest.pageviews, latest.medianAttentionTimeSeconds, latest.medianAttentionTimeByPlatform)
 
     }
   }
@@ -42,7 +42,7 @@ object CampaignService {
       } yield {
         val uniquesDeviceBreakdown = breakdownUniquesByMobileAndDesktop(latest.uniques, latest.uniquesByDevice)
         val uniquesTarget: Long = campaign.targets.getOrElse("uniques", 0)
-        campaign.id -> LatestCampaignAnalytics(latest.campaignId, latest.uniques, uniquesDeviceBreakdown.mobile, uniquesDeviceBreakdown.desktop, uniquesTarget, latest.pageviews)
+        campaign.id -> LatestCampaignAnalytics(latest.campaignId, latest.uniques, uniquesDeviceBreakdown.mobile, uniquesDeviceBreakdown.desktop, uniquesTarget, latest.pageviews, latest.medianAttentionTimeSeconds, latest.medianAttentionTimeByPlatform)
       }
     }
 

--- a/public/components/CampaignPerformanceOverview/CampaignPerformanceOverview.js
+++ b/public/components/CampaignPerformanceOverview/CampaignPerformanceOverview.js
@@ -1,4 +1,25 @@
 import React, { PropTypes } from 'react';
+import R from 'ramda';
+
+class AttentionTimePerPlatform extends React.Component {
+  render () {
+    const items = Object.keys(this.props.medianAttentionTimeSeconds).map ( (platform) => {
+        return (
+          <div key={platform}>
+            <label className="popover-key">{platform}</label>
+            <span className="popover-value">{this.props.medianAttentionTimeSeconds[platform]} seconds</span>
+          </div>
+      )
+    });
+
+    return (
+      <div className="hover-popover">
+        {items}
+      </div>
+    )
+  }
+}
+
 
 export default class CampaignPerformanceOverview extends React.Component {
 
@@ -23,6 +44,9 @@ export default class CampaignPerformanceOverview extends React.Component {
     const uniquesFromMobilePercentage = Math.round(100 * uniquesFromMobile/uniquesSoFar);
     const uniquesFromDesktopPercentage = Math.round(100 * uniquesFromDesktop/uniquesSoFar);
 
+    const medianAttentionTime = this.props.latestAnalyticsForCampaign.medianAttentionTimeSeconds;
+    const medianPerPlatform = this.props.latestAnalyticsForCampaign.medianAttentionTimeByPlatform || {};
+
     return (
       <div className="campaign-info campaign-box-section">
         <div className="campaign-box-section__header">
@@ -36,6 +60,16 @@ export default class CampaignPerformanceOverview extends React.Component {
           <div className="campaign-info__field">
             <label>Uniques so far</label>
             <span className="campaign-info__field__value">{uniquesSoFar ? uniquesSoFar : "none available"} {this.renderPercentageOfTarget(uniquesSoFar, uniquesTarget)} ({uniquesFromMobilePercentage}% on mobile, {uniquesFromDesktopPercentage}% on desktop)</span>
+          </div>
+          <div className="campaign-info__field">
+            <label className={ R.isEmpty(medianPerPlatform) ? "" : "hover" }>
+              Median attention time (All platforms)
+              <div className="hover-content">
+                <AttentionTimePerPlatform medianAttentionTimeSeconds={ medianPerPlatform } />
+              </div>
+            </label>
+            <span className="campaign-info__field__value">{ medianAttentionTime ? `${medianAttentionTime} seconds` : "not available" }</span>
+
           </div>
         </div>
       </div>

--- a/public/styles/components/campaign-info/_campaign-info.scss
+++ b/public/styles/components/campaign-info/_campaign-info.scss
@@ -42,6 +42,7 @@
   color: rgb(237, 237, 237);
   border-radius: 5px;
   padding: 1em;
+  margin-top: 6px;
   width: auto;
   position: absolute;
 }
@@ -62,6 +63,10 @@
 }
 
 .hover-content {
+  visibility: hidden;
+}
+
+.hover-popover:hover {
   visibility: hidden;
 }
 

--- a/public/styles/components/campaign-info/_campaign-info.scss
+++ b/public/styles/components/campaign-info/_campaign-info.scss
@@ -36,3 +36,32 @@
 
   border-radius: 3px;
 }
+
+.hover-popover {
+  background-color: rgb(50, 58, 71);
+  color: rgb(237, 237, 237);
+  border-radius: 5px;
+  padding: 1em;
+  width: auto;
+  position: absolute;
+}
+
+.popover-key {
+  margin-right: 0.5em;
+  font-weight: bold;
+}
+
+.hover {
+  border-bottom: thin dotted black;
+  margin-bottom: 5px;
+  padding-bottom: 0;
+}
+
+.hover:hover .hover-content {
+  visibility: visible;
+}
+
+.hover-content {
+  visibility: hidden;
+}
+


### PR DESCRIPTION
## Changes

This adds a new field to the campaign performance overview page; median attention time.

It adds both median attention time over all platforms, and also breaks it down per platform, which can be displayed if you hover over the text.

## Screenshots

![nohover](https://user-images.githubusercontent.com/445472/29869726-14565598-8d7c-11e7-8c30-74000faa9110.png)

![onhover](https://user-images.githubusercontent.com/445472/29869778-46509734-8d7c-11e7-80f1-8cfba81dd8b4.png)



@LATaylor-guardian 