### PR TITLE
Median attention time device

### DIFF
--- a/app/model/LatestCampaignAnalytics.scala
+++ b/app/model/LatestCampaignAnalytics.scala
@@ -11,7 +11,7 @@ case class LatestCampaignAnalytics(
                                     uniquesTarget: Long,
                                     pageviews: Long,
                                     medianAttentionTimeSeconds: Option[Long],
-                                    medianAttentionTimeByPlatform: Option[Map[String, Long]])
+                                    medianAttentionTimeByDevice: Option[Map[String, Long]])
 
 object LatestCampaignAnalytics {
   implicit val latestCampaignAnalyticsFormat: Format[LatestCampaignAnalytics] = Jsonx.formatCaseClass[LatestCampaignAnalytics]

--- a/app/model/LatestCampaignAnalyticsItem.scala
+++ b/app/model/LatestCampaignAnalyticsItem.scala
@@ -17,7 +17,7 @@ case class LatestCampaignAnalyticsItem(
                                  pageviewsByDevice: Map[String, Long],
                                  uniquesByDevice: Map[String, Long],
                                  medianAttentionTimeSeconds: Option[Long],
-                                 medianAttentionTimeByPlatform: Option[Map[String, Long]]
+                                 medianAttentionTimeByDevice: Option[Map[String, Long]]
                                ){
   def toItem = Item.fromJSON(Json.toJson(this).toString())
 }

--- a/public/components/CampaignPerformanceOverview/CampaignPerformanceOverview.js
+++ b/public/components/CampaignPerformanceOverview/CampaignPerformanceOverview.js
@@ -2,21 +2,24 @@ import React, { PropTypes } from 'react';
 import R from 'ramda';
 
 class AttentionTimePerPlatform extends React.Component {
-  render () {
-    const items = Object.keys(this.props.medianAttentionTimeSeconds).map ( (platform) => {
-        return (
-          <div key={platform}>
-            <label className="popover-key">{platform}</label>
-            <span className="popover-value">{this.props.medianAttentionTimeSeconds[platform]} seconds</span>
-          </div>
-      )
+  render() {
+
+    console.log(this.props.medianAttentionTimeSeconds);
+    console.log(Object.keys(this.props.medianAttentionTimeSeconds));
+    const items = Object.keys(this.props.medianAttentionTimeSeconds).sort().map((deviceType) => {
+      return (
+        <div key={deviceType}>
+          <label className="popover-key">{deviceType}</label>
+          <span className="popover-value">{this.props.medianAttentionTimeSeconds[deviceType]} SECONDS</span>
+        </div>
+      );
     });
 
     return (
       <div className="hover-popover">
         {items}
       </div>
-    )
+    );
   }
 }
 
@@ -45,7 +48,7 @@ export default class CampaignPerformanceOverview extends React.Component {
     const uniquesFromDesktopPercentage = Math.round(100 * uniquesFromDesktop/uniquesSoFar);
 
     const medianAttentionTime = this.props.latestAnalyticsForCampaign.medianAttentionTimeSeconds;
-    const medianPerPlatform = this.props.latestAnalyticsForCampaign.medianAttentionTimeByPlatform || {};
+    const medianPerDevice = this.props.latestAnalyticsForCampaign.medianAttentionTimeByDevice || {};
 
     return (
       <div className="campaign-info campaign-box-section">
@@ -62,10 +65,10 @@ export default class CampaignPerformanceOverview extends React.Component {
             <span className="campaign-info__field__value">{uniquesSoFar ? uniquesSoFar : "none available"} {this.renderPercentageOfTarget(uniquesSoFar, uniquesTarget)} ({uniquesFromMobilePercentage}% on mobile, {uniquesFromDesktopPercentage}% on desktop)</span>
           </div>
           <div className="campaign-info__field">
-            <label className={ R.isEmpty(medianPerPlatform) ? "" : "hover" }>
+            <label className={ R.isEmpty(medianPerDevice) ? "" : "hover" }>
               Median attention time (All platforms)
               <div className="hover-content">
-                <AttentionTimePerPlatform medianAttentionTimeSeconds={ medianPerPlatform } />
+                <AttentionTimePerPlatform medianAttentionTimeSeconds={ medianPerDevice } />
               </div>
             </label>
             <span className="campaign-info__field__value">{ medianAttentionTime ? `${medianAttentionTime} seconds` : "not available" }</span>

--- a/public/components/CampaignPerformanceOverview/CampaignPerformanceOverview.js
+++ b/public/components/CampaignPerformanceOverview/CampaignPerformanceOverview.js
@@ -3,9 +3,6 @@ import R from 'ramda';
 
 class AttentionTimePerPlatform extends React.Component {
   render() {
-
-    console.log(this.props.medianAttentionTimeSeconds);
-    console.log(Object.keys(this.props.medianAttentionTimeSeconds));
     const items = Object.keys(this.props.medianAttentionTimeSeconds).sort().map((deviceType) => {
       return (
         <div key={deviceType}>


### PR DESCRIPTION
Switch the popup under `median attention time` to use `device_type` instead of `platform`. We also normalise the data instead of leaving as the raw `device_type` data.

@kelvin-chappell @LATaylor-guardian 