### PR TITLE
Show full dataset of referrals per campaign

### DIFF
--- a/app/model/CampaignReferral.scala
+++ b/app/model/CampaignReferral.scala
@@ -1,14 +1,9 @@
 package model
 
-import java.math.BigInteger
 import java.time.LocalDate
 
-import com.amazonaws.services.dynamodbv2.document.Item
-import play.api.Logger
 import play.api.libs.json._
 import repositories.CampaignReferralRepository
-
-import scala.util.control.NonFatal
 
 case class Component(
   platform: String,
@@ -18,19 +13,7 @@ case class Component(
   containerName: String,
   cardIndex: Int,
   cardName: String
-) {
-
-  object MD5 {
-    def hash(s: String): String = {
-      val digest = java.security.MessageDigest.getInstance("MD5")
-      val bytes  = s.getBytes("UTF-8")
-      digest.update(bytes, 0, bytes.length)
-      new BigInteger(1, digest.digest()).toString(16)
-    }
-  }
-
-  val hash: String = MD5.hash(toString)
-}
+)
 
 object Component {
   implicit val componentWrites: Writes[Component] = Json.writes[Component]
@@ -38,7 +21,6 @@ object Component {
 
 // A referral to any item in a campaign from an on-platform source in a particular period
 case class CampaignReferral(
-  campaignId: String,
   component: Component,
   numClicks: Int,
   firstReferral: LocalDate,
@@ -47,56 +29,8 @@ case class CampaignReferral(
 
 object CampaignReferral {
 
-  // dynamodb item -> CampaignReferral
-  implicit val itemReads: Reads[CampaignReferral] = Reads { json =>
-    val platformUrlComponent: Seq[String] = (json \ "platformUrlComponent").as[String].split("\\|").toSeq
-
-    def platform(s: String) = s match {
-      case "NEXT_GEN" => "Web"
-      case _          => "unknown"
-    }
-
-    def ifPresent(s: Option[String]): String = s.map(_.trim) getOrElse "unknown"
-
-    def indexIfPresent(s: Option[String], prefix: String): Int = s.map(_.trim.stripPrefix(prefix).toInt) getOrElse -1
-
-    def asDate(js: JsLookupResult): LocalDate = LocalDate.parse(js.as[String])
-
-    JsSuccess(
-      CampaignReferral(
-        campaignId = (json \ "campaignId").as[String],
-        component = Component(
-          platform = ifPresent(platformUrlComponent.headOption.map(platform)),
-          edition = ifPresent(platformUrlComponent.lift(3)),
-          path = ifPresent(platformUrlComponent.lift(4)),
-          containerIndex = indexIfPresent(platformUrlComponent.lift(5), "container-"),
-          containerName = ifPresent(platformUrlComponent.lift(6)),
-          cardIndex = indexIfPresent(platformUrlComponent.lift(8), "card-"),
-          cardName = ifPresent(platformUrlComponent.lift(9))
-        ),
-        numClicks = (json \ "clicks").as[Int],
-        firstReferral = asDate(json \ "firstReferral"),
-        lastReferral = asDate(json \ "lastReferral")
-      )
-    )
-  }
-
   implicit val referralWrites: Writes[CampaignReferral] = Json.writes[CampaignReferral]
 
-  def forCampaign(campaignId: String): Seq[CampaignReferral] = {
-    val (unknown, known) = CampaignReferralRepository.getCampaignReferrals(campaignId) partition (_.component.path == "unknown")
-    unknown foreach { referral =>
-      Logger.warn(s"Unknown referral: $referral")
-    }
-    known
-  }
-
-  def fromItem(item: Item): Option[CampaignReferral] =
-    try {
-      Some(Json.parse(item.toJSON).as[CampaignReferral])
-    } catch {
-      case NonFatal(e) =>
-        Logger.error(s"failed to load referral ${item.toJSON}", e)
-        None
-    }
+  def forCampaign(campaignId: String): Seq[CampaignReferral] =
+    CampaignReferralRepository.getCampaignReferrals(campaignId)
 }

--- a/app/model/CampaignReferralRow.scala
+++ b/app/model/CampaignReferralRow.scala
@@ -1,0 +1,36 @@
+package model
+
+import com.amazonaws.services.dynamodbv2.document.Item
+import play.api.Logger
+import play.api.libs.json.{Json, Reads}
+
+import scala.util.control.NonFatal
+
+case class CampaignReferralRow(
+  campaignId: String,
+  hash: String,
+  referralDate: String,
+  platform: String,
+  edition: Option[String],
+  path: Option[String],
+  containerIndex: Option[Int],
+  containerName: Option[String],
+  cardIndex: Option[Int],
+  cardName: Option[String],
+  clicks: Long,
+  unparsedComponent: Option[String]
+)
+
+object CampaignReferralRow {
+
+  implicit val itemReads: Reads[CampaignReferralRow] = Json.reads[CampaignReferralRow]
+
+  def fromItem(item: Item): Option[CampaignReferralRow] =
+    try {
+      Some(Json.parse(item.toJSON).as[CampaignReferralRow])
+    } catch {
+      case NonFatal(e) =>
+        Logger.error(s"failed to load referral ${item.toJSON}", e)
+        None
+    }
+}

--- a/app/repositories/CampaignReferralRepository.scala
+++ b/app/repositories/CampaignReferralRepository.scala
@@ -2,14 +2,10 @@ package repositories
 
 import java.time.LocalDate
 
-import com.amazonaws.services.dynamodbv2.document.Item
-import model.{CampaignReferral, Component}
-import play.api.Logger
-import play.api.libs.json._
+import model.{CampaignReferral, CampaignReferralRow, Component}
 import services.Dynamo
 
 import scala.collection.JavaConversions._
-import scala.util.control.NonFatal
 
 object CampaignReferralRepository {
 
@@ -53,33 +49,4 @@ object CampaignReferralRepository {
       .sortBy(_.numClicks)
       .reverse
   }
-}
-
-case class CampaignReferralRow(
-  campaignId: String,
-  hash: String,
-  referralDate: String,
-  platform: String,
-  edition: Option[String],
-  path: Option[String],
-  containerIndex: Option[Int],
-  containerName: Option[String],
-  cardIndex: Option[Int],
-  cardName: Option[String],
-  clicks: Long,
-  unparsedComponent: Option[String]
-)
-
-object CampaignReferralRow {
-
-  implicit val itemReads: Reads[CampaignReferralRow] = Json.reads[CampaignReferralRow]
-
-  def fromItem(item: Item): Option[CampaignReferralRow] =
-    try {
-      Some(Json.parse(item.toJSON).as[CampaignReferralRow])
-    } catch {
-      case NonFatal(e) =>
-        Logger.error(s"failed to load referral ${item.toJSON}", e)
-        None
-    }
 }

--- a/app/repositories/CampaignReferralRepository.scala
+++ b/app/repositories/CampaignReferralRepository.scala
@@ -1,17 +1,85 @@
 package repositories
 
-import model.CampaignReferral
+import java.time.LocalDate
+
+import com.amazonaws.services.dynamodbv2.document.Item
+import model.{CampaignReferral, Component}
+import play.api.Logger
+import play.api.libs.json._
 import services.Dynamo
 
 import scala.collection.JavaConversions._
+import scala.util.control.NonFatal
 
 object CampaignReferralRepository {
 
-  def getCampaignReferrals(campaignId: String): Seq[CampaignReferral] =
-    Dynamo.campaignReferralTable
+  def getCampaignReferrals(campaignId: String): Seq[CampaignReferral] = {
+
+    val rows = Dynamo.campaignReferralTable
       .query("campaignId", campaignId)
-      .flatMap(CampaignReferral.fromItem)
+      .flatMap(CampaignReferralRow.fromItem)
+      .toList
+
+    val groupedRows = rows.groupBy(row => (row.platform, row.edition, row.path, row.containerIndex, row.cardIndex))
+
+    def formatPlatform(platform: String): String = platform match {
+      case "NEXT_GEN"           => "Web"
+      case "ANDROID_NATIVE_APP" => "Android"
+      case "IOS_NATIVE_APP"     => "iOS"
+      case "WINDOWS_NATIVE_APP" => "Windows"
+      case other                => other
+    }
+
+    groupedRows
+      .map { row =>
+        val (platform, edition, path, containerIndex, cardIndex) = row._1
+        val groupedValues                                        = row._2
+        CampaignReferral(
+          component = Component(
+            platform = formatPlatform(platform),
+            edition = edition getOrElse "unknown",
+            path = path getOrElse "unknown",
+            containerIndex = containerIndex getOrElse 0,
+            containerName = groupedValues.headOption.flatMap(_.containerName) getOrElse "",
+            cardIndex = cardIndex getOrElse 0,
+            cardName = groupedValues.headOption.flatMap(_.cardName) getOrElse ""
+          ),
+          numClicks = groupedValues.map(_.clicks).sum.toInt,
+          firstReferral = LocalDate.parse(groupedValues.map(_.referralDate).min),
+          lastReferral = LocalDate.parse(groupedValues.map(_.referralDate).max)
+        )
+      }
       .toList
       .sortBy(_.numClicks)
       .reverse
+  }
+}
+
+case class CampaignReferralRow(
+  campaignId: String,
+  hash: String,
+  referralDate: String,
+  platform: String,
+  edition: Option[String],
+  path: Option[String],
+  containerIndex: Option[Int],
+  containerName: Option[String],
+  cardIndex: Option[Int],
+  cardName: Option[String],
+  clicks: Long,
+  unparsedComponent: Option[String]
+)
+
+object CampaignReferralRow {
+
+  implicit val itemReads: Reads[CampaignReferralRow] = Json.reads[CampaignReferralRow]
+
+  def fromItem(item: Item): Option[CampaignReferralRow] =
+    try {
+      Some(Json.parse(item.toJSON).as[CampaignReferralRow])
+    } catch {
+      case NonFatal(e) =>
+        Logger.error(s"failed to load referral ${item.toJSON}", e)
+        None
+    }
 }

--- a/app/services/Config.scala
+++ b/app/services/Config.scala
@@ -43,7 +43,7 @@ sealed trait Config {
   def campaignPageviewsTableName = s"campaign-central-$stage-campaign-page-views"
   def campaignUniquesTableName = s"campaign-central-$stage-campaign-uniques"
   def latestCampaignAnalyticsTableName = s"campaign-central-$stage-analytics-latest"
-  def campaignReferralTableName = s"campaign-central-$stage-referrals"
+  def campaignReferralTableName = s"campaign-central-$stage-referralsv2"
 
   def tagManagerApiUrl: String
   def composerUrl: String
@@ -127,7 +127,8 @@ object StagingDfpProperties {
 }
 
 class DevConfig extends Config {
-  // todo
+
+  //  override def stage = "DEV"
   override def stage = "PROD"
 
   override def logShippingStreamName = Some("elk-CODE-KinesisStream-M03ERGK5PVD9")

--- a/public/components/CampaignAnalytics/Analytics/CampaignReferrals.js
+++ b/public/components/CampaignAnalytics/Analytics/CampaignReferrals.js
@@ -17,14 +17,14 @@ class CampaignReferrals extends React.Component {
     }
   }
 
-  renderReferral = (referral) => {
+  renderReferral = (referral, index) => {
 
     const dateFormat = (date) => {
       return new Date(date).toLocaleDateString('en-GB', {day: '2-digit', month: 'short', year: 'numeric'})
     };
 
     return (
-      <div key={referral.hash} className="campaign-referral-list__item">
+      <div key={index} className="campaign-referral-list__item">
         <div className="campaign-referral-list__row">
           <div className="campaign-referral-list__platform">{referral.component.platform}</div>
           <div className="campaign-referral-list__edition">{referral.component.edition}</div>
@@ -45,7 +45,6 @@ class CampaignReferrals extends React.Component {
       return (
         <div className="campaign-info campaign-box">
           <div className="campaign-box__header">Referrals from on-platform</div>
-          <div>*** Under construction ***</div>
           <div className="campaign-box__body">
             <ProgressSpinner/>
           </div>
@@ -57,7 +56,6 @@ class CampaignReferrals extends React.Component {
       return (
         <div className="campaign-info campaign-box">
           <div className="campaign-box__header">Referrals from on-platform</div>
-          <div>*** Under construction ***</div>
           <div className="campaign-box__body">
             <div className="campaign-referral-list campaign-assets__field__value">
               <div className="campaign-referral-list__row">
@@ -80,7 +78,6 @@ class CampaignReferrals extends React.Component {
     return (
       <div className="campaign-info campaign-box">
         <div className="campaign-box__header">Referrals from on-platform</div>
-        <div>*** Under construction ***</div>
         <div className="campaign-box__body">
           <span className="campaign-assets__field__value">No traffic has been referred from on-platform to this campaign yet.</span>
         </div>


### PR DESCRIPTION
This now shows results for all platforms, so that the sum of all the referral clicks should equal the number of page views for the campaign.