### PR TITLE
Update import mechanism to properly set state upon failure

### DIFF
--- a/public/components/CapiImport/CapiImport.js
+++ b/public/components/CapiImport/CapiImport.js
@@ -77,11 +77,7 @@ class CapiImport extends Component {
         this.context.router.push('/campaign/' + campaign.id);
       }).catch((error) => {
         console.error(error);
-        if (error.response) {
-          this.setState({importing: false, error: error.response});
-        } else {
-          this.setState({importing: false});
-        }
+        this.setState({importing: false, error: 'Something went wrong; please try again'});
       });
 
     } else {

--- a/public/components/CapiImport/CapiImport.js
+++ b/public/components/CapiImport/CapiImport.js
@@ -75,14 +75,21 @@ class CapiImport extends Component {
 
         this.setState({importing: false});
         this.context.router.push('/campaign/' + campaign.id);
-      })
+      }).catch((error) => {
+        console.error(error);
+        if (error.response) {
+          this.setState({importing: false, error: error.response});
+        } else {
+          this.setState({importing: false});
+        }
+      });
 
     } else {
       this.setState({
         error: 'All required fields must be present before the campaign can be imported.'
       });
     }
-  }
+  };
 
   validateNumericInput = (value, errorState, successState) => {
     const numValue = parseInt(value);


### PR DESCRIPTION
I can't see why it would fail in setting the state to `{importing: false}` unless an exception in the `Promise` has occurred.

This updates to catch all exceptions and if a response exists, show it to the user.

@LATaylor-guardian @kelvin-chappell 