### PR TITLE
Modernise to AMIgo and deb packages

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,14 +35,28 @@ lazy val dependencies = Seq(
   "org.scalatest" %% "scalatest" % "3.0.3" % Test
 )
 
-lazy val root = (project in file(".")).enablePlugins(PlayScala, SbtWeb, RiffRaffArtifact)
+lazy val root = (project in file(".")).enablePlugins(PlayScala, SbtWeb, RiffRaffArtifact, JDebPackaging, SystemdPlugin)
   .settings(Defaults.coreDefaultSettings: _*)
   .settings(
+    javaOptions in Universal ++= Seq(
+      "-Dpidfile.path=/dev/null",
+      "-J-XX:MaxRAMFraction=2",
+      "-J-XX:InitialRAMFraction=2",
+      "-J-XX:MaxMetaspaceSize=500m",
+      "-J-XX:+UseConcMarkSweepGC",
+      "-J-XX:+PrintGCDetails",
+      "-J-XX:+PrintGCDateStamps",
+      s"-J-Xloggc:/var/log/${packageName.value}/gc.log"
+    ),
+    debianPackageDependencies := Seq("openjdk-8-jre-headless"),
+    maintainer := "Editorial Tools Developers <digitalcms.dev@theguardian.com>",
+    packageSummary := description.value,
+    packageDescription := description.value,
     playDefaultPort := 2267,
     packageName in Universal := normalizedName.value,
     name in Universal := normalizedName.value,
     topLevelDirectory in Universal := Some(normalizedName.value),
-    riffRaffPackageType := (packageZipTarball in config("universal")).value,
+    riffRaffPackageType := (packageBin in Debian).value,
     riffRaffBuildIdentifier := Option(System.getenv("CIRCLE_BUILD_NUM")).getOrElse("DEV"),
     riffRaffUploadArtifactBucket := Option("riffraff-artifact"),
     riffRaffUploadManifestBucket := Option("riffraff-builds"),

--- a/build.sbt
+++ b/build.sbt
@@ -49,7 +49,7 @@ lazy val root = (project in file(".")).enablePlugins(PlayScala, SbtWeb, RiffRaff
       s"-J-Xloggc:/var/log/${packageName.value}/gc.log"
     ),
     debianPackageDependencies := Seq("openjdk-8-jre-headless"),
-    maintainer := "Editorial Tools Developers <digitalcms.dev@theguardian.com>",
+    maintainer := "Commercial Dev Team <commercial.dev@theguardian.com>",
     packageSummary := description.value,
     packageDescription := description.value,
     playDefaultPort := 2267,

--- a/circle.yml
+++ b/circle.yml
@@ -17,6 +17,7 @@ dependencies:
   # Cache the resolution-cache and build streams to speed things up
   cache_directories:
     - "~/.sbt"
+    - "~/.coursier"
     - "target/resolution-cache"
     - "target/streams"
     - "project/target/resolution-cache"

--- a/cloudformation/campaign-central.yaml
+++ b/cloudformation/campaign-central.yaml
@@ -39,11 +39,6 @@ Parameters:
     Type: String
     Default: 77.91.248.0/21
 
-  GithubTeamName:
-    Description: Github team name, used for giving ssh access to members of the team.
-    Type: String
-    Default: Editorial-Tools-SSHAccess
-
   LogsKinesisStreamName:
     Description: The kinesis stream to send logs to
     Type: String
@@ -156,11 +151,11 @@ Resources:
           Action:
           - s3:GetObject
           Resource:
-          - arn:aws:s3:::github-team-keys/*
+          - arn:aws:s3:::github-public-keys/*
         - Effect: Allow
           Action:
           - s3:ListBucket
-          Resource: arn:aws:s3:::github-team-keys
+          Resource: arn:aws:s3:::github-public-keys
       Roles:
       - Ref: CampaignCentralRole
 

--- a/cloudformation/campaign-central.yaml
+++ b/cloudformation/campaign-central.yaml
@@ -30,8 +30,8 @@ Parameters:
     Type: List<AWS::EC2::Subnet::Id>
     Default: subnet-c2620fa7,subnet-2a37bd5d,subnet-2967c870
 
-  MachineImagesAMI:
-    Description: AMI id from the machine-images repo
+  AMI:
+    Description: AMIgo AMI id
     Type: AWS::EC2::Image::Id
 
   GuardianIP:
@@ -362,7 +362,7 @@ Resources:
       KeyName:
         Ref: KeyName
       ImageId:
-        Ref: MachineImagesAMI
+        Ref: AMI
       SecurityGroups:
       - Ref: AppServerSecurityGroup
       - Ref: SSHSecurityGroup
@@ -375,14 +375,7 @@ Resources:
         Ref: CampaignCentralInstanceProfile
       UserData:
         Fn::Base64:
-          Fn::Join:
-          - ''
-          - - "#!/bin/bash -ev\n"
-            - "/opt/features/gnm-ca/install.sh\n"
-            - Fn::Join:
-              - ''
-              - - "/opt/features/ssh-keys/initialise-keys-and-cron-job.sh -b github-team-keys
-                  -t "
-                - Ref: GithubTeamName
-                - " -l || true\n"
-            - "/opt/features/native-packager/install.sh -b composer-dist -t tgz -s\n"
+          Fn::Sub: |
+            #!/bin/bash -ev
+            aws s3 cp s3://composer-dist/flexible/${Stage}/campaign-central/campaign-central_1.0_all.deb /tmp/campaign-central.deb
+            dpkg -i /tmp/campaign-central.deb

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,4 +10,8 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.0")
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.1")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.7")
+
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC10")
+
+libraryDependencies += "org.vafer" % "jdeb" % "1.3" artifacts (Artifact("jdeb", "jar", "jar"))

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -8,7 +8,7 @@ deployments:
     app: campaign-central
     parameters:
       amiTags:
-        Recipe: editorial-tools-xenial-java8
+        Recipe: xenial-commercial-dev
         AmigoStage: PROD
         BuiltBy: amigo
   campaign-central:

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -3,7 +3,17 @@ stacks:
 regions:
 - eu-west-1
 deployments:
+  ami-update:
+    type: ami-cloudformation-parameter
+    app: campaign-central
+    parameters:
+      amiTags:
+        Recipe: editorial-tools-xenial-java8
+        AmigoStage: PROD
+        BuiltBy: amigo
   campaign-central:
     type: autoscaling
     parameters:
       bucket: composer-dist
+    dependencies:
+    - ami-update


### PR DESCRIPTION
Update the CFN, riff-raff.yaml and build process to:
 - create a debian package and then download and install this on instance boot
 - use images from AMIgo that are updates automatically when deployed
 - use coursier for faster build times

I had forgotten that this wasn't really looked after by Ed Tools anymore so here is some free update work for y'all.

__*Note that the CFN change and a new deploy must be done in lockstep. Any outstanding PRs must rebase after this in order to be able to build and deploy.*__