### PR TITLE
Add dwell time data per campaign.

### DIFF
--- a/app/model/LatestCampaignAnalytics.scala
+++ b/app/model/LatestCampaignAnalytics.scala
@@ -11,7 +11,9 @@ case class LatestCampaignAnalytics(
                                     uniquesTarget: Long,
                                     pageviews: Long,
                                     medianAttentionTimeSeconds: Option[Long],
-                                    medianAttentionTimeByDevice: Option[Map[String, Long]])
+                                    medianAttentionTimeByDevice: Option[Map[String, Long]],
+                                    weightedAverageDwellTimeForCampaign: Double,
+                                    averageDwellTimePerPathSeconds: Map[String, Double])
 
 object LatestCampaignAnalytics {
   implicit val latestCampaignAnalyticsFormat: Format[LatestCampaignAnalytics] = Jsonx.formatCaseClass[LatestCampaignAnalytics]

--- a/app/model/LatestCampaignAnalyticsItem.scala
+++ b/app/model/LatestCampaignAnalyticsItem.scala
@@ -17,7 +17,9 @@ case class LatestCampaignAnalyticsItem(
                                  pageviewsByDevice: Map[String, Long],
                                  uniquesByDevice: Map[String, Long],
                                  medianAttentionTimeSeconds: Option[Long],
-                                 medianAttentionTimeByDevice: Option[Map[String, Long]]
+                                 medianAttentionTimeByDevice: Option[Map[String, Long]],
+                                 weightedAverageDwellTimeForCampaign: Double,
+                                 averageDwellTimePerPathSeconds: Map[String, Double]
                                ){
   def toItem = Item.fromJSON(Json.toJson(this).toString())
 }

--- a/app/services/Config.scala
+++ b/app/services/Config.scala
@@ -128,8 +128,7 @@ object StagingDfpProperties {
 
 class DevConfig extends Config {
 
-  //  override def stage = "DEV"
-  override def stage = "PROD"
+  override def stage = "DEV"
 
   override def logShippingStreamName = Some("elk-CODE-KinesisStream-M03ERGK5PVD9")
 

--- a/app/util/DoubleWithPrecision.scala
+++ b/app/util/DoubleWithPrecision.scala
@@ -1,0 +1,8 @@
+package util
+
+object DoubleUtils {
+  implicit class DoubleWithPrecision(val value: Double) {
+    def to2Dp: Double = BigDecimal(value).setScale(2, BigDecimal.RoundingMode.HALF_UP).toDouble
+  }
+}
+

--- a/public/components/CampaignPerformanceOverview/CampaignPerformanceOverview.js
+++ b/public/components/CampaignPerformanceOverview/CampaignPerformanceOverview.js
@@ -6,8 +6,27 @@ class AttentionTimePerPlatform extends React.Component {
     const items = Object.keys(this.props.medianAttentionTimeSeconds).sort().map((deviceType) => {
       return (
         <div key={deviceType}>
-          <label className="popover-key">{deviceType}</label>
-          <span className="popover-value">{this.props.medianAttentionTimeSeconds[deviceType]} SECONDS</span>
+          <label className="popover-key">{deviceType} :</label>
+          <span className="popover-value">{this.props.medianAttentionTimeSeconds[deviceType]} seconds</span>
+        </div>
+      );
+    });
+
+    return (
+      <div className="hover-popover">
+        {items}
+      </div>
+    );
+  }
+}
+
+class AverageDwellTimePerPath extends React.Component {
+  render() {
+    const items = Object.keys(this.props.averageDwellTimePerPathSeconds).sort().map((path) => {
+      return (
+        <div key={path}>
+          <label className="popover-key">{path} :</label>
+          <span className="popover-value">{this.props.averageDwellTimePerPathSeconds[path]} seconds</span>
         </div>
       );
     });
@@ -46,6 +65,9 @@ export default class CampaignPerformanceOverview extends React.Component {
 
     const medianAttentionTime = this.props.latestAnalyticsForCampaign.medianAttentionTimeSeconds;
     const medianPerDevice = this.props.latestAnalyticsForCampaign.medianAttentionTimeByDevice || {};
+    
+    const weightedAverageDwellTime = this.props.latestAnalyticsForCampaign.weightedAverageDwellTimeForCampaign;
+    const averageDwellTimePerPathSeconds = this.props.latestAnalyticsForCampaign.averageDwellTimePerPathSeconds || {};
 
     return (
       <div className="campaign-info campaign-box-section">
@@ -69,7 +91,15 @@ export default class CampaignPerformanceOverview extends React.Component {
               </div>
             </label>
             <span className="campaign-info__field__value">{ medianAttentionTime ? `${medianAttentionTime} seconds` : "not available" }</span>
-
+          </div>
+          <div className="campaign-info__field">
+            <label className={ R.isEmpty(averageDwellTimePerPathSeconds) ? "" : "hover" }>
+              Weighted average dwell time
+              <div className="hover-content">
+                <AverageDwellTimePerPath averageDwellTimePerPathSeconds={ averageDwellTimePerPathSeconds } />
+              </div>
+            </label>
+            <span className="campaign-info__field__value">{weightedAverageDwellTime ? `${weightedAverageDwellTime} seconds` : "none available"} </span>
           </div>
         </div>
       </div>

--- a/public/styles/components/campaign-info/_campaign-info.scss
+++ b/public/styles/components/campaign-info/_campaign-info.scss
@@ -48,8 +48,14 @@
 }
 
 .popover-key {
+  text-transform: lowercase !important;
   margin-right: 0.5em;
   font-weight: bold;
+}
+
+.popover-value {
+  text-transform: lowercase !important;
+  color: #37c7ba;
 }
 
 .hover {


### PR DESCRIPTION
Provides the weighted average dwell time per campaign along with the average dwell time per path.

![picture 140](https://user-images.githubusercontent.com/8861681/30283604-6e880fe6-9710-11e7-98b4-f10352116f9b.png)

