### PR TITLE
Fix import form to carry values

### DIFF
--- a/app/model/command/ImportCampaignFromCAPICommand.scala
+++ b/app/model/command/ImportCampaignFromCAPICommand.scala
@@ -142,9 +142,7 @@ case class ImportCampaignFromCAPICommand(
         case Some(_) => "paidContent"
         case None => InvalidCampaignTagType
       }
-
-      Some("uniques" -> uniquesTarget) ++ pageviewTarget.map("pageviews" -> _).toMap
-
+      
       val campaign = CampaignRepository.getCampaignByTag(tag.id) getOrElse {
         Campaign(
           id = UUID.randomUUID().toString,

--- a/app/model/command/ImportCampaignFromCAPICommand.scala
+++ b/app/model/command/ImportCampaignFromCAPICommand.scala
@@ -106,9 +106,9 @@ object ImportTag {
 
 case class ImportCampaignFromCAPICommand(
                                         tag: ImportTag,
+                                        campaignValue: Long,
                                         uniquesTarget: Long,
-                                        pageviewTarget: Long,
-                                        campaignValue: Option[Long]
+                                        pageviewTarget: Option[Long]
                                         ) extends CAPIImportCommand {
 
 
@@ -143,6 +143,8 @@ case class ImportCampaignFromCAPICommand(
         case None => InvalidCampaignTagType
       }
 
+      Some("uniques" -> uniquesTarget) ++ pageviewTarget.map("pageviews" -> _).toMap
+
       val campaign = CampaignRepository.getCampaignByTag(tag.id) getOrElse {
         Campaign(
           id = UUID.randomUUID().toString,
@@ -156,9 +158,9 @@ case class ImportCampaignFromCAPICommand(
           createdBy = userOrDefault,
           lastModified = now,
           lastModifiedBy = userOrDefault,
-          nominalValue = Some(10000),         // default targets and values
-          actualValue = Some(10000),          // these will be set in the UI manually
-          targets = Map("uniques" -> 10000L)
+          nominalValue = None,                        // default targets and values
+          actualValue = Some(campaignValue),          // these will be set in the UI manually
+          targets = (Some("uniques" -> uniquesTarget) ++ pageviewTarget.map("pageviews" -> _)).toMap
         )
       }
 

--- a/public/components/CapiImport/CapiImport.js
+++ b/public/components/CapiImport/CapiImport.js
@@ -51,7 +51,6 @@ class CapiImport extends Component {
 
     const isCampaignValueSet = this.state.campaignValue && this.state.campaignValue > 0;
     const isUniquesTargetSet = this.state.uniquesTarget && this.state.uniquesTarget > 0;
-    const isPageviewsTargetSet = this.state.pageviewsTarget && this.state.pageviewsTarget > 0;
     const selectedTag = this.state.selectedTag;
 
     const payload = {

--- a/public/components/CapiImport/CapiImport.js
+++ b/public/components/CapiImport/CapiImport.js
@@ -54,11 +54,17 @@ class CapiImport extends Component {
     const isPageviewsTargetSet = this.state.pageviewsTarget && this.state.pageviewsTarget > 0;
     const selectedTag = this.state.selectedTag;
 
+    const payload = {
+      tag: this.state.selectedTag,
+      campaignValue: this.state.campaignValue,
+      uniquesTarget: this.state.uniquesTarget,
+      pageviewTarget: this.state.pageviewsTarget
+    };
 
     if (isCampaignValueSet && isUniquesTargetSet && selectedTag) {
       this.setState({importing: true});
 
-      importCampaignFromTag(selectedTag).then((campaign) => {
+      importCampaignFromTag(payload).then((campaign) => {
 
         let updatedTargets = undefined;
 
@@ -87,41 +93,41 @@ class CapiImport extends Component {
     }
   };
 
-  validateNumericInput = (value, errorState, successState) => {
-    const numValue = parseInt(value);
-
-    if (!value) {
+  validateNumericInput = (originalValue, parsedAsInt, errorState, successState) => {
+    if (!originalValue) {
       this.setState({error: ''});
-    } else if (isNaN(numValue) || numValue != value) {
+    } else if (isNaN(parsedAsInt) || parsedAsInt != originalValue) {
       this.setState(errorState);
     } else {
       this.setState(successState);
     }
-
   };
 
   onCampaignValueChange = (e) => {
     const campaignValue = e.target.value;
-    const successState = { error: '', campaignValue: campaignValue };
+    const campaignValueAsInt = parseInt(e.target.value);
+    const successState = { error: '', campaignValue: campaignValueAsInt };
     const errorState = { error: 'Campaign value has to be a number!' };
 
-    this.validateNumericInput(campaignValue, errorState, successState);
+    this.validateNumericInput(campaignValue, campaignValueAsInt, errorState, successState);
   };
 
   onPageviewsTargetChange = (e) => {
     const pageviewsTarget = e.target.value;
-    const successState = { error: '', pageviewsTarget: pageviewsTarget };
+    const pageviewsTargetAsInt = parseInt(e.target.value);
+    const successState = { error: '', pageviewsTarget: pageviewsTargetAsInt };
     const errorState = { error: 'Pageviews target value has to be a number!' };
 
-    this.validateNumericInput(pageviewsTarget, errorState, successState);
+    this.validateNumericInput(pageviewsTarget, pageviewsTargetAsInt, errorState, successState);
   };
 
   onUniquesTargetChange = (e) => {
     const uniquesTarget = e.target.value;
-    const successState = { error: '', uniquesTarget: uniquesTarget };
+    const uniquesTargetAsInt = parseInt(e.target.value);
+    const successState = { error: '', uniquesTarget: uniquesTargetAsInt };
     const errorState = { error: 'Uniques target value has to be a number!' };
 
-    this.validateNumericInput(uniquesTarget, errorState, successState);
+    this.validateNumericInput(uniquesTarget, uniquesTargetAsInt, errorState, successState);
   };
 
   performSearch(searchTerm) {
@@ -157,7 +163,7 @@ class CapiImport extends Component {
       return(<ProgressSpinner />);
     }
     return;
-  }
+  };
 
   render() {
 

--- a/public/components/CapiImport/CapiImport.js
+++ b/public/components/CapiImport/CapiImport.js
@@ -151,19 +151,19 @@ class CapiImport extends Component {
           <fieldset>
             <div className="pure-control-group">
               <label htmlFor="name">Campaign Value (£)</label>
-              <input id="name" type="text" placeholder="" onChange={this.onInputChange.bind(this, 'campaignValue')} />
+              <input id="name" type="text" autoComplete="off" placeholder="" onChange={this.onInputChange.bind(this, 'campaignValue')} />
                 <span className="pure-form-message-inline">required</span>
             </div>
 
             <div className="pure-control-group">
               <label htmlFor="name">Uniques Target</label>
-              <input id="name" type="text" placeholder="" onChange={this.onInputChange.bind(this, 'uniquesTarget')} />
+              <input id="name" type="text" autoComplete="off" placeholder="" onChange={this.onInputChange.bind(this, 'uniquesTarget')} />
               <span className="pure-form-message-inline">required</span>
             </div>
 
             <div className="pure-control-group">
               <label htmlFor="name">Pageviews Target</label>
-              <input id="name" type="text" placeholder="" onChange={this.onInputChange.bind(this, 'pageviewsTarget')}/>
+              <input id="name" type="text" autoComplete="off" placeholder="" onChange={this.onInputChange.bind(this, 'pageviewsTarget')}/>
               <span className="pure-form-message-inline">optional</span>
             </div>
 

--- a/public/components/CapiImport/CapiImport.js
+++ b/public/components/CapiImport/CapiImport.js
@@ -65,20 +65,6 @@ class CapiImport extends Component {
       this.setState({importing: true});
 
       importCampaignFromTag(payload).then((campaign) => {
-
-        let updatedTargets = undefined;
-
-        if (isPageviewsTargetSet) {
-          updatedTargets = Object.assign({}, campaign.targets, { ['uniques']: this.state.uniquesTarget, ['pageviews']: this.state.pageviewsTarget });
-        } else {
-          updatedTargets = Object.assign({}, campaign.targets, { ['uniques']: this.state.uniquesTarget });
-        }
-
-        this.props.updateCampaign(Object.assign({}, campaign, {
-          actualValue: this.state.campaignValue,
-          targets: updatedTargets
-        }));
-
         this.setState({importing: false});
         this.context.router.push('/campaign/' + campaign.id);
       }).catch((error) => {

--- a/public/components/CapiImport/CapiImport.js
+++ b/public/components/CapiImport/CapiImport.js
@@ -93,42 +93,34 @@ class CapiImport extends Component {
     }
   };
 
-  validateNumericInput = (originalValue, parsedAsInt, errorState, successState) => {
-    if (!originalValue) {
-      this.setState({error: ''});
-    } else if (isNaN(parsedAsInt) || parsedAsInt != originalValue) {
-      this.setState(errorState);
+  validateState = () => {
+    const errors = ['campaignValue', 'uniquesTarget', 'pageviewsTarget'].reduce((errorsAccum, dataToCheck) => {
+      const value = this.state[dataToCheck];
+      if (value !== undefined && isNaN(value)) {
+        errorsAccum.push(`${dataToCheck} value has to be a number!`);
+      }
+
+      return errorsAccum;
+    }, []);
+
+    if (errors.length > 0) {
+      this.setState({error: errors[0]});
     } else {
-      this.setState(successState);
+      this.setState({error: ''});
     }
   };
 
-  onCampaignValueChange = (e) => {
-    const campaignValue = e.target.value;
-    const campaignValueAsInt = parseInt(e.target.value);
-    const successState = { error: '', campaignValue: campaignValueAsInt };
-    const errorState = { error: 'Campaign value has to be a number!' };
+  onInputChange = (keyName, event) => {
+    const newValue = event.target.value;
 
-    this.validateNumericInput(campaignValue, campaignValueAsInt, errorState, successState);
+    if (newValue === '' || newValue === undefined) {
+      this.setState({[keyName]: undefined}, this.validateState);
+    } else if (newValue) {
+      const valueAsInt = Number(newValue);
+      this.setState({[keyName]: valueAsInt}, this.validateState);
+    }
   };
 
-  onPageviewsTargetChange = (e) => {
-    const pageviewsTarget = e.target.value;
-    const pageviewsTargetAsInt = parseInt(e.target.value);
-    const successState = { error: '', pageviewsTarget: pageviewsTargetAsInt };
-    const errorState = { error: 'Pageviews target value has to be a number!' };
-
-    this.validateNumericInput(pageviewsTarget, pageviewsTargetAsInt, errorState, successState);
-  };
-
-  onUniquesTargetChange = (e) => {
-    const uniquesTarget = e.target.value;
-    const uniquesTargetAsInt = parseInt(e.target.value);
-    const successState = { error: '', uniquesTarget: uniquesTargetAsInt };
-    const errorState = { error: 'Uniques target value has to be a number!' };
-
-    this.validateNumericInput(uniquesTarget, uniquesTargetAsInt, errorState, successState);
-  };
 
   performSearch(searchTerm) {
     const searchParams = {query: searchTerm || this.state.searchTerm};
@@ -174,19 +166,19 @@ class CapiImport extends Component {
           <fieldset>
             <div className="pure-control-group">
               <label htmlFor="name">Campaign Value (£)</label>
-              <input id="name" type="text" placeholder="" onChange={this.onCampaignValueChange} />
+              <input id="name" type="text" placeholder="" onChange={this.onInputChange.bind(this, 'campaignValue')} />
                 <span className="pure-form-message-inline">required</span>
             </div>
 
             <div className="pure-control-group">
               <label htmlFor="name">Uniques Target</label>
-              <input id="name" type="text" placeholder="" onChange={this.onUniquesTargetChange} />
+              <input id="name" type="text" placeholder="" onChange={this.onInputChange.bind(this, 'uniquesTarget')} />
               <span className="pure-form-message-inline">required</span>
             </div>
 
             <div className="pure-control-group">
               <label htmlFor="name">Pageviews Target</label>
-              <input id="name" type="text" placeholder="" onChange={this.onPageviewsTargetChange}/>
+              <input id="name" type="text" placeholder="" onChange={this.onInputChange.bind(this, 'pageviewsTarget')}/>
               <span className="pure-form-message-inline">optional</span>
             </div>
 

--- a/public/components/CapiImport/CapiImport.js
+++ b/public/components/CapiImport/CapiImport.js
@@ -7,7 +7,7 @@ class CapiImport extends Component {
 
   static contextTypes = {
     router: React.PropTypes.object.isRequired
-  }
+  };
 
   constructor(props) {
     super(props);


### PR DESCRIPTION
This updates the import form;
 - Carry `campaignValue`, `uniquesTarget` and `pageviewsTarget` into the campaign
 - Fix the workflow so that it brings you to the campaign you have just created/already exists
 - Remove autocomplete from the form
 - Fix the validation on the form to show errors on whole form rather than only on the field being edited

@kelvin-chappell @LATaylor-guardian 