### PR TITLE
Make average dwell time optional in model.

### DIFF
--- a/app/model/LatestCampaignAnalytics.scala
+++ b/app/model/LatestCampaignAnalytics.scala
@@ -12,8 +12,8 @@ case class LatestCampaignAnalytics(
                                     pageviews: Long,
                                     medianAttentionTimeSeconds: Option[Long],
                                     medianAttentionTimeByDevice: Option[Map[String, Long]],
-                                    weightedAverageDwellTimeForCampaign: Double,
-                                    averageDwellTimePerPathSeconds: Map[String, Double])
+                                    weightedAverageDwellTimeForCampaign: Option[Double],
+                                    averageDwellTimePerPathSeconds: Option[Map[String, Double]])
 
 object LatestCampaignAnalytics {
   implicit val latestCampaignAnalyticsFormat: Format[LatestCampaignAnalytics] = Jsonx.formatCaseClass[LatestCampaignAnalytics]

--- a/app/model/LatestCampaignAnalyticsItem.scala
+++ b/app/model/LatestCampaignAnalyticsItem.scala
@@ -18,8 +18,8 @@ case class LatestCampaignAnalyticsItem(
                                  uniquesByDevice: Map[String, Long],
                                  medianAttentionTimeSeconds: Option[Long],
                                  medianAttentionTimeByDevice: Option[Map[String, Long]],
-                                 weightedAverageDwellTimeForCampaign: Double,
-                                 averageDwellTimePerPathSeconds: Map[String, Double]
+                                 weightedAverageDwellTimeForCampaign: Option[Double],
+                                 averageDwellTimePerPathSeconds: Option[Map[String, Double]]
                                ){
   def toItem = Item.fromJSON(Json.toJson(this).toString())
 }

--- a/app/services/CampaignService.scala
+++ b/app/services/CampaignService.scala
@@ -39,8 +39,8 @@ object CampaignService {
         latest.pageviews,
         latest.medianAttentionTimeSeconds,
         latest.medianAttentionTimeByDevice.map(normaliseDeviceData),
-        latest.weightedAverageDwellTimeForCampaign.to2Dp,
-        latest.averageDwellTimePerPathSeconds.mapValues(_.to2Dp)
+        latest.weightedAverageDwellTimeForCampaign.map(_.to2Dp),
+        latest.averageDwellTimePerPathSeconds.map(_.mapValues(_.to2Dp))
       )
 
     }
@@ -68,8 +68,8 @@ object CampaignService {
             uniquesTarget, latest.pageviews,
             latest.medianAttentionTimeSeconds,
             latest.medianAttentionTimeByDevice.map(normaliseDeviceData),
-            latest.weightedAverageDwellTimeForCampaign.to2Dp,
-            latest.averageDwellTimePerPathSeconds.mapValues(_.to2Dp)
+            latest.weightedAverageDwellTimeForCampaign.map(_.to2Dp),
+            latest.averageDwellTimePerPathSeconds.map(_.mapValues(_.to2Dp))
           )
       }
     }


### PR DESCRIPTION
It's possible for the dwell time data to not be written to Dynamo. This prevents it blowing up.