### PR TITLE
Remove the default User

### DIFF
--- a/app/controllers/CampaignApi.scala
+++ b/app/controllers/CampaignApi.scala
@@ -4,7 +4,6 @@ import com.gu.googleauth.AuthAction
 import model._
 import model.command.{CampaignNotFound, ImportCampaignFromCAPICommand, RefreshCampaignFromCAPICommand}
 import model.reports._
-import org.joda.time.DateTime
 import play.api.Logger
 import play.api.libs.json.Json._
 import play.api.libs.json._
@@ -87,7 +86,7 @@ class CampaignApi(components: ControllerComponents, authAction: AuthAction[AnyCo
   }
 
   def importFromTag() = authAction { req =>
-    implicit val user: Option[User] = Option(User(req.user))
+    implicit val user: User = User(req.user)
     req.body.asJson map { json =>
       json.as[ImportCampaignFromCAPICommand].process() match {
         case Left(_) =>
@@ -101,7 +100,7 @@ class CampaignApi(components: ControllerComponents, authAction: AuthAction[AnyCo
   }
 
   def refreshCampaignFromCAPI(campaignId: String) = authAction { req =>
-    implicit val user: Option[User] = Option(User(req.user))
+    implicit val user: User = User(req.user)
     RefreshCampaignFromCAPICommand(campaignId).process() match {
       case Right(campaign)                 => Ok(Json.toJson(campaign))
       case Left(CampaignNotFound(message)) => NotFound(message)

--- a/app/controllers/ManagementApi.scala
+++ b/app/controllers/ManagementApi.scala
@@ -75,7 +75,7 @@ class ManagementApi(components: ControllerComponents, authAction: AuthAction[Any
 
     expiringCampaigns foreach { c =>
       Logger.info(s"campaign ${c.name} is due to expire, refreshing from CAPI")
-      RefreshCampaignFromCAPICommand(c.id).process()(Some(user))
+      RefreshCampaignFromCAPICommand(c.id).process()(user)
     }
 
     NoContent

--- a/app/model/command/ImportCampaignFromCAPICommand.scala
+++ b/app/model/command/ImportCampaignFromCAPICommand.scala
@@ -19,8 +19,6 @@ object Section {
 
 trait CAPIImportCommand {
 
-  val defaultUser: User = User("CAPI", "importer", "labs.beta@guardian.co.uk")
-
   def deriveHostedTagFromContent(content: List[ApiContent]): Option[Tag] = {
     content.flatMap(_.tags).find { t =>
       t.`type` == TagType.PaidContent


### PR DESCRIPTION
There is no need to wrap `User` in an `Option` only to the try to take it back out and then fail back to the `defaultUser` if it doesn't exist; it should always exists.

This means all process now implicitly require a `User` object in scope.

@kelvin-chappell @LATaylor-guardian 