### PR TITLE
Switch back to the number format for JodaDate

### DIFF
--- a/app/model/Campaign.scala
+++ b/app/model/Campaign.scala
@@ -1,13 +1,11 @@
 package model
 
 import ai.x.play.json.Jsonx
-import com.amazonaws.services.dynamodbv2.document.Item
-import org.joda.time.DateTime
 import cats.syntax.either._
+import com.amazonaws.services.dynamodbv2.document.Item
 import model.command.{CampaignCentralApiError, JsonParsingError}
-import play.api.libs.json.{Format, JsValue, Json}
-import play.api.libs.json.JodaReads._
-import play.api.libs.json.JodaWrites._
+import org.joda.time.DateTime
+import play.api.libs.json._
 
 case class Campaign(
   id: String,
@@ -39,7 +37,9 @@ case class Campaign(
 }
 
 object Campaign {
-  implicit val campaignFormat: Format[Campaign] = Jsonx.formatCaseClass[Campaign]
+  implicit val campaignFormat: Format[Campaign]    = Jsonx.formatCaseClass[Campaign]
+  implicit val defaultJodaReads: Reads[DateTime]   = JodaReads.DefaultJodaDateTimeReads
+  implicit val defaultJodaWrites: Writes[DateTime] = JodaWrites.JodaDateTimeNumberWrites
 
   def fromJson(json: JsValue): Either[CampaignCentralApiError, Campaign] =
     json.asOpt[Campaign].map(Right(_)) getOrElse Left(JsonParsingError(""))


### PR DESCRIPTION
## Problem

When `ophan-stream` reads out the `Campaign` data in order to make datalake queries, it reads the `startDate` and `endDate` as `Long`s in unix timestamp format.

When we upgraded to `play 2.6`, the default `Format` for `joda.DateTime` got removed and put into its own library in `play-json-joda`; on top of this, the default `Reads` and `Writes` changed from a unix timestamp to `ISO-8601`. The reason for this change to the default format was because it now preserves the timezone, which the unix timestamp does not carry.

After this got deployed, campaigns would seemingly randomly stop reporting uniques and pageviews, but in fact this was when people would save the campaign running the `play 2.6` application, blocking `ophan-stream` from reading the data.

## Fix

This changes back to the unix timestamp number format, meaning that `ophan-stream` can read it correctly again. We aren't so sensitive to time in this project; although if this is to be used globally, we probably want to switch to the string format, although this will be a bigger change.

@kelvin-chappell @LATaylor-guardian 

