### PR TITLE
Fix the z-index of the popover

### DIFF
--- a/public/styles/components/campaign-info/_campaign-info.scss
+++ b/public/styles/components/campaign-info/_campaign-info.scss
@@ -45,6 +45,7 @@
   margin-top: 6px;
   width: auto;
   position: absolute;
+  z-index: 999;
 }
 
 .popover-key {


### PR DESCRIPTION
Sometimes the dwell time popover ends up being long and going under the chart beneath.

@kelvin-chappell @LATaylor-guardian 