### PR TITLE
Add a Glossary

### DIFF
--- a/conf/routes
+++ b/conf/routes
@@ -5,6 +5,7 @@ GET	/campaigns/:id		            controllers.App.index(id)
 GET	/campaign/:id		              controllers.App.index(id)
 GET	/capiImport		                controllers.App.index(id = "")
 GET	/management/analytics         controllers.App.index(id = "")
+GET	/glossary                     controllers.App.index(id = "")
 
 
 GET /login            controllers.LogIn.logIn()

--- a/public/components/CampaignPerformanceOverview/CampaignPerformanceOverview.js
+++ b/public/components/CampaignPerformanceOverview/CampaignPerformanceOverview.js
@@ -1,5 +1,7 @@
 import React, { PropTypes } from 'react';
 import R from 'ramda';
+import { DwellTimeExplainerText, MedianAttentionTimeExplainerText } from '../Glossary/Glossary';
+
 
 class AttentionTimePerPlatform extends React.Component {
   render() {
@@ -39,6 +41,30 @@ class AverageDwellTimePerPath extends React.Component {
   }
 }
 
+class Explainer extends React.Component {
+  explainerStyle = {
+    margin: '0 0.4em 0 0.2em',
+    display: 'inline-block',
+    cursor: 'pointer',
+  };
+
+  questionMarkPosition = {
+    position: 'absolute',
+    textDecoration: 'underline dotted',
+    top: 0,
+  };
+
+  render() {
+    return (
+      <div style={this.explainerStyle} className="explainer hover">
+        <div style={this.questionMarkPosition} className="question-mark">?</div>
+        <div className="hover-content">
+          <div className="hover-popover">{this.props.text}</div>
+        </div>
+      </div>
+    );
+  }
+}
 
 export default class CampaignPerformanceOverview extends React.Component {
 
@@ -65,7 +91,7 @@ export default class CampaignPerformanceOverview extends React.Component {
 
     const medianAttentionTime = this.props.latestAnalyticsForCampaign.medianAttentionTimeSeconds;
     const medianPerDevice = this.props.latestAnalyticsForCampaign.medianAttentionTimeByDevice || {};
-    
+
     const weightedAverageDwellTime = this.props.latestAnalyticsForCampaign.weightedAverageDwellTimeForCampaign;
     const averageDwellTimePerPathSeconds = this.props.latestAnalyticsForCampaign.averageDwellTimePerPathSeconds || {};
 
@@ -90,6 +116,7 @@ export default class CampaignPerformanceOverview extends React.Component {
                 <AttentionTimePerPlatform medianAttentionTimeSeconds={ medianPerDevice } />
               </div>
             </label>
+            <Explainer text={MedianAttentionTimeExplainerText} />
             <span className="campaign-info__field__value">{ medianAttentionTime ? `${medianAttentionTime} seconds` : "not available" }</span>
           </div>
           <div className="campaign-info__field">
@@ -99,6 +126,7 @@ export default class CampaignPerformanceOverview extends React.Component {
                 <AverageDwellTimePerPath averageDwellTimePerPathSeconds={ averageDwellTimePerPathSeconds } />
               </div>
             </label>
+            <Explainer text={DwellTimeExplainerText} />
             <span className="campaign-info__field__value">{weightedAverageDwellTime ? `${weightedAverageDwellTime} seconds` : "none available"} </span>
           </div>
         </div>

--- a/public/components/Glossary/Glossary.js
+++ b/public/components/Glossary/Glossary.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const MedianAttentionTimeExplainerText = 'Attention time is the measure of how long a user is knowingly active on the page; they have recently moved their mouse or scrolled.';
+const MedianAttentionTimeExplainerText = 'Attention time is the measure of how long a user is knowingly active on the page; they have recently moved their mouse or scrolled within 5 seconds, or are watching a video in a focused tab.';
 const DwellTimeExplainerText = 'Dwell time tries to emulate the same viewability metric from Google Analytics. It is calculated by taking the difference between a pageview timestamp and the subsequent pageview timestamp. These pageviews have to happen within a 30 minute session period, and are averaged when there has been more than one pageview for a unique user.';
 
 class Glossary extends React.Component {

--- a/public/components/Glossary/Glossary.js
+++ b/public/components/Glossary/Glossary.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const MedianAttentionTimeExplainerText = 'Attention time is the value where a user is knowingly active on the page; they have recently moved their mouse or scrolled.';
+const MedianAttentionTimeExplainerText = 'Attention time is the measure of how long a user is knowingly active on the page; they have recently moved their mouse or scrolled.';
 const DwellTimeExplainerText = 'Dwell time tries to emulate the same viewability metric from Google Analytics. It is calculated by taking the difference between a pageview timestamp and the subsequent pageview timestamp. These pageviews have to happen within a 30 minute session period, and are averaged when there has been more than one pageview for a unique user.';
 
 class Glossary extends React.Component {

--- a/public/components/Glossary/Glossary.js
+++ b/public/components/Glossary/Glossary.js
@@ -1,0 +1,20 @@
+import React from 'react';
+
+const MedianAttentionTimeExplainerText = 'Attention time is the value where a user is knowingly active on the page; they have recently moved their mouse or scrolled.';
+const DwellTimeExplainerText = 'Dwell time tries to emulate the same viewability metric from Google Analytics. It is calculated by taking the difference between a pageview timestamp and the subsequent pageview timestamp. These pageviews have to happen within a 30 minute session period, and are averaged when there has been more than one pageview for a unique user.';
+
+class Glossary extends React.Component {
+
+  render() {
+    return (
+      <div className="glossary">
+        <h1>Median Attention Time</h1>
+        <p>{MedianAttentionTimeExplainerText}</p>
+        <h1>Average Dwell Time</h1>
+        <p>{DwellTimeExplainerText}</p>
+      </div>
+    );
+  }
+}
+
+export { Glossary, DwellTimeExplainerText, MedianAttentionTimeExplainerText };

--- a/public/components/Sidebar/Sidebar.js
+++ b/public/components/Sidebar/Sidebar.js
@@ -34,6 +34,7 @@ export default class Sidebar extends React.Component {
         <div className="sidebar__link-group">
           <div className="sidebar__link-group__header">Tools</div>
           <SidebarLink to="/capiImport">Import campaign</SidebarLink>
+          <SidebarLink to="/glossary">Glossary</SidebarLink>
         </div>
       </div>
     );

--- a/public/router.js
+++ b/public/router.js
@@ -8,6 +8,8 @@ import Campaign from './components/Campaign/Campaign';
 import CapiImport from './components/CapiImport/CapiImport';
 import AnalyticsCache from './components/Management/AnalyticsCache';
 
+import { Glossary } from './components/Glossary/Glossary';
+
 export const router = (
   <Router history={browserHistory}>
     <Route path="/" component={Main}>
@@ -17,6 +19,7 @@ export const router = (
       <Route path="/campaign/:id" component={Campaign} />
       <Route path="/capiImport" component={CapiImport} />
       <Route path="/management/analytics" component={AnalyticsCache} />
+      <Route path="/glossary" component={Glossary} />
     </Route>
   </Router>
 );

--- a/public/styles/components/campaign-info/_campaign-info.scss
+++ b/public/styles/components/campaign-info/_campaign-info.scss
@@ -10,6 +10,8 @@
 
     padding: 5px 0;
   }
+
+  position: relative;
 }
 
 .campaign-info__field__value {
@@ -43,7 +45,8 @@
   border-radius: 5px;
   padding: 1em;
   margin-top: 6px;
-  width: auto;
+  left: 0;
+  right: auto;
   position: absolute;
   z-index: 999;
 }


### PR DESCRIPTION
This adds a glossary page that describes the terms; it also adds a question mark beside the terms in the campaign performance metrics page that when you hover over, will display the text.

@LATaylor-guardian Is working on something similar that reworks the metrics page; so this question mark piece may get removed.

@kelvin-chappell 