### PR TITLE
Add method to return the desired string for referral path

### DIFF
--- a/app/repositories/CampaignReferralRepository.scala
+++ b/app/repositories/CampaignReferralRepository.scala
@@ -29,7 +29,7 @@ object CampaignReferralRepository {
             CampaignReferral(
               component = Component(
                 platform = formatPlatform(platform),
-                path = path getOrElse "unknown",
+                path = formatPath(path),
                 containerIndex = containerIndex getOrElse 0,
                 containerName = groupedValues.headOption.flatMap(_.containerName) getOrElse "",
                 cardIndex = cardIndex getOrElse 0,
@@ -59,5 +59,13 @@ object CampaignReferralRepository {
     case "IOS_NATIVE_APP"     => "iOS"
     case "WINDOWS_NATIVE_APP" => "Windows"
     case other                => other
+  }
+
+  private def formatPath(maybePath: Option[String]): String = {
+    maybePath match {
+      case Some(s) if s.startsWith("uk/") => s.stripPrefix("uk")
+      case Some(p)                        => p
+      case _                              => "unknown"
+    }
   }
 }


### PR DESCRIPTION
#### What is changing and why:

fix for the path coming from native apps within the referrals table ([trello card](https://trello.com/c/Wlw8n5LK/111-campaign-central-referrals-fix-path-coming-from-native-apps))

Android and iOS apps are currently including the edition as a prefix on the path, for example: `uk/royal-canin-cats` should actually be: `/royal-canin-cats`

This adds a method that deals with the gettingOrElse of path, and strips any `uk` prefix

##### Before:

<img width="647" alt="picture 38" src="https://user-images.githubusercontent.com/8607683/31353007-c4222e36-ad28-11e7-8534-d771f026ddef.png">

##### After:

<img width="644" alt="picture 36" src="https://user-images.githubusercontent.com/8607683/31352970-9b80c5f0-ad28-11e7-926a-7de9b3224e08.png">