### PR TITLE
Provide initial breakdown of campaign performance by location and device.

### DIFF
--- a/app/controllers/ManagementApi.scala
+++ b/app/controllers/ManagementApi.scala
@@ -18,7 +18,6 @@ class ManagementApi(components: ControllerComponents) extends AbstractController
   val Stage = Config.conf.stage.toUpperCase
 
   def refreshCampaigns = Action.async { implicit request =>
-
     val isRefreshCampaignAllowed: Boolean = request.queryString.get("api-key").flatMap(_.headOption) match {
       case Some(apiKey) if apiKey == Config.conf.campaignCentralApiKey && Stage == "PROD" => true
       case Some(_) | None if Stage == "DEV"                                               => true

--- a/app/model/LatestCampaignAnalytics.scala
+++ b/app/model/LatestCampaignAnalytics.scala
@@ -3,6 +3,15 @@ package model
 import ai.x.play.json.Jsonx
 import play.api.libs.json.Format
 
+import scala.collection.immutable.ListMap
+
+case class LatestAnalyticsBreakdownItem(uniques: Long, pageviews: Long)
+
+object LatestAnalyticsBreakdownItem {
+  implicit val latestCampaignAnalyticsBreakdownItemFormat: Format[LatestAnalyticsBreakdownItem] =
+    Jsonx.formatCaseClass[LatestAnalyticsBreakdownItem]
+}
+
 case class LatestCampaignAnalytics(campaignId: String,
                                    uniques: Long,
                                    uniquesByDevice: Option[Map[String, Long]],
@@ -12,7 +21,9 @@ case class LatestCampaignAnalytics(campaignId: String,
                                    medianAttentionTimeSeconds: Option[Long],
                                    medianAttentionTimeByDevice: Option[Map[String, Long]],
                                    weightedAverageDwellTimeForCampaign: Option[Double],
-                                   averageDwellTimePerPathSeconds: Option[Map[String, Double]])
+                                   averageDwellTimePerPathSeconds: Option[Map[String, Double]],
+                                   analyticsByCountryCode: Map[String, LatestAnalyticsBreakdownItem],
+                                   analyticsByDevice: Map[String, LatestAnalyticsBreakdownItem])
 
 object LatestCampaignAnalytics {
   implicit val latestCampaignAnalyticsFormat: Format[LatestCampaignAnalytics] =
@@ -21,6 +32,28 @@ object LatestCampaignAnalytics {
   def apply(latestCampaignAnalyticsItem: LatestCampaignAnalyticsItem, uniquesTarget: Long): LatestCampaignAnalytics = {
 
     import util.DoubleUtils._
+
+    val metricsByCountryCode: Map[String, LatestAnalyticsBreakdownItem] =
+      latestCampaignAnalyticsItem.uniquesByCountryCode.flatMap {
+        case (key, uniques) =>
+          val maybePageviews = latestCampaignAnalyticsItem.pageviewsByCountryCode.get(key)
+          maybePageviews.map { pageviews =>
+            key -> LatestAnalyticsBreakdownItem(uniques, pageviews)
+          }
+      }
+
+    val metricsByDevice: Map[String, LatestAnalyticsBreakdownItem] =
+      latestCampaignAnalyticsItem.uniquesByDevice.getOrElse(Map.empty).flatMap {
+        case (key, uniques) =>
+          val maybePageviews = latestCampaignAnalyticsItem.pageviewsByDevice.flatMap(_.get(key))
+          maybePageviews.map { pageviews =>
+            key -> LatestAnalyticsBreakdownItem(uniques, pageviews)
+          }
+      }
+
+    def sortByUniques: ((String, LatestAnalyticsBreakdownItem), (String, LatestAnalyticsBreakdownItem)) => Boolean = {
+      case ((_, lb1), (_, lb2)) => lb1.uniques > lb2.uniques
+    }
 
     LatestCampaignAnalytics(
       latestCampaignAnalyticsItem.campaignId,
@@ -32,7 +65,9 @@ object LatestCampaignAnalytics {
       latestCampaignAnalyticsItem.medianAttentionTimeSeconds,
       latestCampaignAnalyticsItem.medianAttentionTimeByDevice.map(normaliseDeviceData),
       latestCampaignAnalyticsItem.weightedAverageDwellTimeForCampaign.map(_.to2Dp),
-      latestCampaignAnalyticsItem.averageDwellTimePerPathSeconds.map(_.mapValues(_.to2Dp))
+      latestCampaignAnalyticsItem.averageDwellTimePerPathSeconds.map(_.mapValues(_.to2Dp)),
+      ListMap(metricsByCountryCode.toSeq.sortWith(sortByUniques): _*),
+      ListMap(metricsByDevice.toSeq.sortWith(sortByUniques): _*)
     )
   }
 

--- a/public/components/Campaign/Campaign.js
+++ b/public/components/Campaign/Campaign.js
@@ -5,6 +5,7 @@ import CampaignAssets from '../CampaignInformationEdit/CampaignAssets';
 import CampaignAnalytics from '../CampaignAnalytics/CampaignAnalytics';
 import CampaignReferrals from '../CampaignAnalytics/Analytics/CampaignReferrals';
 import CampaignPerformanceOverview from '../CampaignPerformanceOverview/CampaignPerformanceOverview';
+import CampaignPerformanceBreakdown from '../CampaignPerformanceBreakdown/CampaignPerformanceBreakdown';
 
 class Campaign extends React.Component {
 
@@ -70,6 +71,10 @@ class Campaign extends React.Component {
         <div className="campaign__row">
           <CampaignPerformanceOverview campaign={campaign}
                         latestAnalyticsForCampaign={this.props.latestAnalyticsForCampaign} />
+
+          <CampaignPerformanceBreakdown campaign={campaign}
+                        latestAnalyticsForCampaign={this.props.latestAnalyticsForCampaign} />
+
           <CampaignEdit campaign={campaign}
                         latestAnalyticsForCampaign={this.props.latestAnalyticsForCampaign}
                         updateCampaign={this.props.campaignActions.updateCampaign}

--- a/public/components/CampaignPerformanceBreakdown/CampaignPerformanceBreakdown.js
+++ b/public/components/CampaignPerformanceBreakdown/CampaignPerformanceBreakdown.js
@@ -1,0 +1,92 @@
+import React, { PropTypes } from 'react';
+
+class CampaignPerformanceBreakdownTable extends React.Component {
+
+  render() {
+
+    const analytics = Object.entries(this.props.analyticsBreakdown || {});
+
+    return (
+      <table className="pure-table">
+        <thead>
+        <tr>
+          <th>{this.props.breakdownLabel}</th>
+          <th>Unique Users</th>
+          <th>Total Page Views</th>
+          <th>Average Time on Page</th>
+        </tr>
+        </thead>
+
+        <tbody>
+        {analytics.map(([breakdownKey, values]) => {
+          return(
+            <tr key={breakdownKey}>
+              <td>{breakdownKey}</td>
+              <td>{values.uniques}</td>
+              <td>{values.pageviews}</td>
+              <td> We do not have this data available yet. </td>
+            </tr>
+          );
+
+        })}
+        </tbody>
+      </table>
+    );
+  }
+}
+
+export default class CampaignPerformanceBreakdown extends React.Component {
+
+  view = {
+    'LOCATION': 'LOCATION',
+    'DEVICE': 'DEVICE'
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      currentView: this.view.LOCATION
+    }
+  }
+
+  onViewChange = (e, selectedView) => {
+    this.setState({
+      currentView: selectedView
+    });
+  }
+
+  renderBreakdownTable() {
+    const analyticsByCountryCode = this.props.latestAnalyticsForCampaign.analyticsByCountryCode || {};
+    const analyticsByDevice = this.props.latestAnalyticsForCampaign.analyticsByDevice || {};
+
+    switch(this.state.currentView) {
+      case this.view.LOCATION:
+        return(<CampaignPerformanceBreakdownTable breakdownLabel="Country" analyticsBreakdown={analyticsByCountryCode}/>);
+      case this.view.DEVICE:
+        return(<CampaignPerformanceBreakdownTable breakdownLabel="Device" analyticsBreakdown={analyticsByDevice}/>);
+      default:
+        return(<CampaignPerformanceBreakdownTable breakdownLabel="Country" analyticsBreakdown={analyticsByCountryCode}/>);
+    }
+  }
+
+  render () {
+
+    return(
+      <div className="campaign__row">
+        <div className="campaign-box__header">Campaign performance Breakdown</div>
+        <div className="campaign-box__body">
+
+        <div id ="performance-breakdown-nav" className="pure-button-group" role="group" aria-label="...">
+          <button className={this.state.currentView === this.view.LOCATION ? 'pure-button pure-button-active' : 'pure-button'} onClick={(e) => this.onViewChange(e, this.view.LOCATION)}>Location</button>
+          <button className={this.state.currentView === this.view.DEVICE ? 'pure-button pure-button-active' : 'pure-button'} onClick={(e) => this.onViewChange(e, this.view.DEVICE)}>Device</button>
+        </div>
+
+        {this.renderBreakdownTable()}
+
+      </div>
+      </div>
+    );
+
+  }
+}

--- a/public/components/CampaignPerformanceOverview/CampaignPerformanceOverview.js
+++ b/public/components/CampaignPerformanceOverview/CampaignPerformanceOverview.js
@@ -1,5 +1,4 @@
 import React, { PropTypes } from 'react';
-import R from 'ramda';
 import BigCardMetric from './BigCardMetric';
 
 export default class CampaignPerformanceOverview extends React.Component {

--- a/public/styles/components/campaign-info/_campaign-info.scss
+++ b/public/styles/components/campaign-info/_campaign-info.scss
@@ -79,3 +79,7 @@
 .hover-popover:hover {
   visibility: hidden;
 }
+
+#performance-breakdown-nav {
+  padding-bottom: 20px;
+}


### PR DESCRIPTION
Still to do in seperate PR:
 - Dwell time by device.
 - Dwell time by country code.
 - Median attention time by device.
 - Median attention time by country code.
 - Dwell time/median attention time/page views/uniques by path.

Screenshots:
-------------
By country:
![picture 151](https://user-images.githubusercontent.com/8861681/31434523-82e04ffa-ae74-11e7-8663-e4f6e4313f48.png)

by device: 
![picture 152](https://user-images.githubusercontent.com/8861681/31434539-89daea2c-ae74-11e7-8c6d-a6b9f7fbf284.png)
