### PR TITLE
Add benchmarks to Campaign Central.

### DIFF
--- a/app/controllers/CampaignApi.scala
+++ b/app/controllers/CampaignApi.scala
@@ -27,6 +27,15 @@ class CampaignApi(components: ControllerComponents, authAction: AuthAction[AnyCo
     }
   }
 
+  def getBenchmarksAcrossCampaigns() = authAction {
+    CampaignService.getBenchmarksAcrossCampaigns() match {
+      case Left(JsonParsingError(error)) => InternalServerError(error)
+      case Left(_)                       => InternalServerError
+      case Right(benchmarks)             => Ok(Json.toJson(benchmarks))
+    }
+
+  }
+
   def getLatestCampaignAnalytics() = authAction {
     CampaignService.getLatestCampaignAnalytics() match {
       case Left(JsonParsingError(error)) => InternalServerError(error)

--- a/app/model/Benchmarks.scala
+++ b/app/model/Benchmarks.scala
@@ -1,0 +1,47 @@
+package model
+
+import ai.x.play.json.Jsonx
+import play.api.libs.json.Format
+import util.DoubleUtils._
+
+case class Totals(uniques: Long, pageviews: Long, timeSpentOnPage: Double)
+object Totals {
+  implicit val totalsFormat: Format[Totals] = Jsonx.formatCaseClass[Totals]
+
+  def apply(latestAnalytics: Seq[LatestCampaignAnalytics]): Totals = {
+    Totals(
+      uniques = latestAnalytics.map(_.uniques).sum,
+      pageviews = latestAnalytics.map(_.pageviews).sum,
+      timeSpentOnPage = latestAnalytics.flatMap(_.weightedAverageDwellTimeForCampaign).sum.to2Dp
+    )
+  }
+}
+
+case class Averages(uniques: Long, pageviews: Long, timeSpentOnPage: Double)
+object Averages {
+  implicit val averagesFormat: Format[Averages] = Jsonx.formatCaseClass[Averages]
+
+  def apply(latestAnalytics: Seq[LatestCampaignAnalytics]): Averages = {
+    val noOfAnalytics = latestAnalytics.size.toLong
+    Averages(
+      uniques = latestAnalytics.map(_.uniques).sum / noOfAnalytics,
+      pageviews = latestAnalytics.map(_.pageviews).sum / noOfAnalytics,
+      timeSpentOnPage = (latestAnalytics.flatMap(_.weightedAverageDwellTimeForCampaign).sum / noOfAnalytics).to2Dp
+    )
+  }
+}
+
+case class PaidFor(totals: Totals, averages: Averages)
+object PaidFor {
+  implicit val paidForFormat: Format[PaidFor] = Jsonx.formatCaseClass[PaidFor]
+}
+case class Hosted(totals: Totals, averages: Averages)
+object Hosted {
+  implicit val hostedFormat: Format[Hosted] = Jsonx.formatCaseClass[Hosted]
+}
+
+case class Benchmarks(totals: Totals, averages: Averages, paidFor: PaidFor, hosted: Hosted)
+
+object Benchmarks {
+  implicit val benchmarksFormat: Format[Benchmarks] = Jsonx.formatCaseClass[Benchmarks]
+}

--- a/conf/routes
+++ b/conf/routes
@@ -6,6 +6,7 @@ GET	/campaign/:id		              controllers.App.index(id)
 GET	/capiImport		                controllers.App.index(id = "")
 GET	/management/analytics         controllers.App.index(id = "")
 GET	/glossary                     controllers.App.index(id = "")
+GET	/benchmarks                   controllers.App.index(id = "")
 
 
 GET /login            controllers.LogIn.logIn()
@@ -16,6 +17,7 @@ GET /oauth2callback   controllers.LogIn.oauth2Callback()
 #Campaign Api
 
 GET /api/campaigns                         controllers.CampaignApi.getAllCampaigns
+GET /api/v2/campaigns/benchmarks           controllers.CampaignApi.getBenchmarksAcrossCampaigns
 GET /api/v2/campaigns/latestAnalytics      controllers.CampaignApi.getLatestCampaignAnalytics
 GET /api/v2/campaigns/:id/latestAnalytics  controllers.CampaignApi.getLatestAnalyticsForCampaign(id: String)
 

--- a/public/actions/CampaignActions/getAllCampaignBenchmarks.js
+++ b/public/actions/CampaignActions/getAllCampaignBenchmarks.js
@@ -1,0 +1,36 @@
+import {getCampaignBenchmarks} from '../../services/CampaignsApi';
+
+function requestBenchmarks() {
+    return {
+        type:       'CAMPAIGN_BENCHMARKS_GET_REQUEST',
+        receivedAt: Date.now()
+    };
+}
+
+function receiveBenchmarks(benchmarks) {
+    return {
+        type:        'CAMPAIGN_BENCHMARKS_GET_RECEIVE',
+        benchmarks:    benchmarks,
+        receivedAt:  Date.now()
+    };
+}
+
+function errorRecievingBenchmarks(error) {
+    return {
+        type:       'SHOW_ERROR',
+        message:    'Could not get bencharks',
+        error:      error,
+        receivedAt: Date.now()
+    };
+}
+
+export function getBenchmarks() {
+    return dispatch => {
+      dispatch(requestBenchmarks());
+      return getCampaignBenchmarks()
+        .catch(error => dispatch(errorRecievingBenchmarks(error)))
+        .then(res => {
+          dispatch(receiveBenchmarks(res));
+        });
+    };
+}

--- a/public/components/CampaignPerformanceOverview/BigCardMetric.js
+++ b/public/components/CampaignPerformanceOverview/BigCardMetric.js
@@ -37,7 +37,7 @@ export default class BigCardMetric extends React.Component {
       <div className="box">
           {this.renderOpenModalIcon()}
           <div className="head">{this.props.metricLabel}</div>
-          <div className="count ">{this.props.metricValue}</div>
+          <div className="count ">{this.props.metricValue.toLocaleString()}</div>
           <div className="unit">{this.props.metricUnit ? this.props.metricUnit : this.props.metricTargetMessage}</div>
           <Modal
               visible={this.state.visible}

--- a/public/components/Campaigns/Benchmarks.js
+++ b/public/components/Campaigns/Benchmarks.js
@@ -1,0 +1,90 @@
+import React, {Component, PropTypes} from 'react';
+import BigCardMetric from '../CampaignPerformanceOverview/BigCardMetric';
+
+
+class BenchmarkSet extends Component {
+
+  render() {
+    const totals = this.props.totals;
+    const averages = this.props.averages;
+
+    return(
+      <div className="campaign__row">
+        <div className="campaign-box__header">{this.props.title}</div>
+        <div className="campaign-box__body">
+          <div id="metrics">
+            <BigCardMetric metricLabel="Total Uniques"
+                           metricValue={totals.uniques}/>
+
+            <BigCardMetric metricLabel="Total Pageviews"
+                           metricValue={totals.pageviews}/>
+
+            <BigCardMetric metricLabel="Total Time on Page"
+                           metricUnit="seconds"
+                           metricValue={totals.timeSpentOnPage}/>
+
+            <BigCardMetric metricLabel="Average Uniques"
+                           metricValue={averages.uniques}/>
+
+            <BigCardMetric metricLabel="Average Pageviews"
+                           metricValue={averages.pageviews}/>
+
+            <BigCardMetric metricLabel="Average Time on Page"
+                           metricUnit="seconds"
+                           metricValue={averages.timeSpentOnPage}/>
+          </div>
+        </div>
+      </div>
+    );
+
+  }
+}
+
+class Benchmarks extends Component {
+
+  componentDidMount() {
+    this.props.benchmarkActions.getBenchmarks();
+  }
+
+  render() {
+    const benchmarks = this.props.benchmarks;
+
+    if (!benchmarks > 0) { return(null) }
+
+    return (
+      <div>
+        <h1>Benchmarks</h1>
+
+        <p style={{lineHeight: 1.5}}>
+          Benchmarks provides an aggregate of the metrics we provide per campaign across all campaigns, including the subsets by campaign type.
+          This data relies on the data per each individual campaign. Therefore if campaigns are missing, their campaign type is incorrect or the start and end date for the
+          campaign are not set correctly in the Tag Manager then this will have an underlining effect on these numbers.
+        </p>
+
+        <BenchmarkSet totals={benchmarks.totals} averages={benchmarks.averages} title="Across All Campaigns" />
+        <BenchmarkSet totals={benchmarks.paidFor.totals} averages={benchmarks.paidFor.averages} title="Across Paid For Campaigns" />
+        <BenchmarkSet totals={benchmarks.hosted.totals} averages={benchmarks.hosted.averages} title="Across Hosted Campaigns" />
+      </div>
+    );
+  }
+}
+
+//REDUX CONNECTIONS
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import * as getAllCampaignBenchmarks from '../../actions/CampaignActions/getAllCampaignBenchmarks';
+
+function mapStateToProps(state) {
+  console.log(state);
+  return {
+    benchmarks: state.benchmarks
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    benchmarkActions: bindActionCreators(Object.assign({}, getAllCampaignBenchmarks), dispatch)
+  };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Benchmarks);

--- a/public/components/Sidebar/Sidebar.js
+++ b/public/components/Sidebar/Sidebar.js
@@ -16,6 +16,7 @@ export default class Sidebar extends React.Component {
       <div className="sidebar">
         <div className="sidebar__link-group">
           <div className="sidebar__link-group__header">Campaigns</div>
+          <SidebarLink to="/benchmarks">Benchmarks</SidebarLink>
           <SidebarLink to="/campaigns">All Campaigns</SidebarLink>
           <div className="sidebar__filter-group">
             <div className="sidebar__filter-group__header">State:</div>

--- a/public/reducers/allCampaignBenchmarksReducer.js
+++ b/public/reducers/allCampaignBenchmarksReducer.js
@@ -1,0 +1,11 @@
+
+export default function benchmarks(state = null, action) {
+  switch (action.type) {
+
+    case 'CAMPAIGN_BENCHMARKS_GET_RECEIVE':
+      return action.benchmarks || false;
+
+    default:
+      return state;
+  }
+}

--- a/public/reducers/rootReducer.js
+++ b/public/reducers/rootReducer.js
@@ -12,6 +12,7 @@ import campaignReferrals from './campaignReferralReducer';
 import campaignSort from './campaignSortReducer';
 import latestAnalytics from './latestAnalyticsReducer';
 import latestAnalyticsForCampaign from './latestAnalyticsForCampaignReducer';
+import benchmarks from './allCampaignBenchmarksReducer';
 
 export default combineReducers({
   error,
@@ -26,5 +27,6 @@ export default combineReducers({
   campaignReferrals,
   campaignSort,
   latestAnalytics,
-  latestAnalyticsForCampaign
+  latestAnalyticsForCampaign,
+  benchmarks
 });

--- a/public/router.js
+++ b/public/router.js
@@ -3,6 +3,7 @@ import {Router, Route, IndexRoute, browserHistory, IndexRedirect} from 'react-ro
 
 import Main from './components/Main';
 import Campaigns from './components/Campaigns/Campaigns';
+import Benchmarks from './components/Campaigns/Benchmarks';
 import Campaign from './components/Campaign/Campaign';
 import { Glossary } from './components/Glossary/Glossary';
 
@@ -11,6 +12,7 @@ export const router = (
     <Route path="/" component={Main}>
       <IndexRedirect to="/campaigns" />
       <Route path="/campaigns" component={Campaigns} />
+      <Route path="/benchmarks" component={Benchmarks} />
       <Route path="/campaigns/:filterName" component={Campaigns} />
       <Route path="/campaign/:id" component={Campaign} />
       <Route path="/glossary" component={Glossary} />

--- a/public/services/CampaignsApi.js
+++ b/public/services/CampaignsApi.js
@@ -86,3 +86,10 @@ export function refreshCampaignFromCAPI(id) {
     method: 'post'
   });
 }
+
+export function getCampaignBenchmarks() {
+  return AuthedReqwest({
+    url: '/api/v2/campaigns/benchmarks',
+    method: 'get'
+  });
+}


### PR DESCRIPTION
Benchmarks is a new page, requested by Chloe, that looks to provide the metrics we provide at campaign level across ALL campaigns. This at current is done manually in a spreadsheet and repeated by one or more people. This information is generally used to give an idea of what sales can use to sell and is informative in that process.
<img width="960" alt="picture 155" src="https://user-images.githubusercontent.com/8861681/31542432-d768b38c-b009-11e7-8a52-825495f9b792.png">

