### PR TITLE
Ensure Hosted campaigns are marked as so.

### DIFF
--- a/app/repositories/contentapi/CapiSectionTransformer.scala
+++ b/app/repositories/contentapi/CapiSectionTransformer.scala
@@ -18,8 +18,10 @@ object CapiSectionTransformer {
 
   def deriveCampaignName(section: CapiSection): String = section.webTitle
 
-  def deriveSponsorshipType(section: CapiSection): Option[String] =
-    section.activeSponsorships.flatMap(_.headOption.map(_.sponsorshipType.name))
+  def deriveSponsorshipType(section: CapiSection): Option[String] = {
+    def isHosted(section: CapiSection): Boolean = section.id.startsWith("advertiser-content")
+    if (isHosted(section)) Some("hosted") else section.activeSponsorships.flatMap(_.headOption.map(_.sponsorshipType.name))
+  }
 
   def deriveSponsorshipLogo(section: CapiSection): Option[String] =
     section.activeSponsorships.getOrElse(Nil).headOption.map(sponsorship => sponsorship.sponsorLogo)


### PR DESCRIPTION
A hosted campaigns ID will always begin with 'advertiser-content' as opposed to paid for type campaigns which do not.