### PR TITLE
If a section no longer has an active sponsorship mark campaign as finished.

### DIFF
--- a/app/model/LatestCampaignAnalytics.scala
+++ b/app/model/LatestCampaignAnalytics.scala
@@ -49,14 +49,14 @@ object LatestCampaignAnalytics {
 
     val top20PlusSumOfOtherMetricsByCountryCode: Map[String, LatestAnalyticsBreakdownItem] = {
       val sortedMetricsByCountryCode = ListMap(metricsByCountryCode.toSeq.sortWith(sortByUniques): _*)
-      val (top20, other) = sortedMetricsByCountryCode.splitAt(20)
+      val (top20, other)             = sortedMetricsByCountryCode.splitAt(20)
 
       top20 + ("other" ->
         LatestAnalyticsBreakdownItem(
           uniques = other.values.map(_.uniques).sum,
           pageviews = other.values.map(_.pageviews).sum,
           timeSpentOnPage = Some(other.values.flatMap(_.timeSpentOnPage).sum)
-      ))
+        ))
     }
 
     val metricsByDevice: Map[String, LatestAnalyticsBreakdownItem] =

--- a/app/repositories/contentapi/CapiSectionTransformer.scala
+++ b/app/repositories/contentapi/CapiSectionTransformer.scala
@@ -20,7 +20,8 @@ object CapiSectionTransformer {
 
   def deriveSponsorshipType(section: CapiSection): Option[String] = {
     def isHosted(section: CapiSection): Boolean = section.id.startsWith("advertiser-content")
-    if (isHosted(section)) Some("hosted") else section.activeSponsorships.flatMap(_.headOption.map(_.sponsorshipType.name.toLowerCase))
+    if (isHosted(section)) Some("hosted")
+    else section.activeSponsorships.flatMap(_.headOption.map(_.sponsorshipType.name.toLowerCase))
   }
 
   def deriveSponsorshipLogo(section: CapiSection): Option[String] =

--- a/app/services/CampaignTransformer.scala
+++ b/app/services/CampaignTransformer.scala
@@ -61,4 +61,8 @@ object CampaignTransformer {
 
   }
 
+  def updateExistingCampaignThatsFinished(campaign: Campaign): Campaign = {
+    campaign.copy(status = "dead")
+  }
+
 }


### PR DESCRIPTION
When a campaign is finished it will be removed from the active sponsorships on the Section corresponding to it in CAPI and will disappear from the endpoint we use to synchronise campaigns. In this case we should do the following: 

1. Take all sections from CAPI as A.
2. Take all existing campaigns in Dynamo as B.
3. Take all items from B diff A (== pathPrefix) as C.
4. Mark all campaigns in C as "dead".
