### PR TITLE
Upgrade capi client (which contains a change in http client)

### DIFF
--- a/app/services/CampaignService.scala
+++ b/app/services/CampaignService.scala
@@ -185,6 +185,8 @@ object CampaignService {
           Logger.warn(s"Could not create campaign from section: ${section.id}")
           None
         }
+
+      case _ => None
     }
 
     val updatedCampaignsOrError: List[Either[CampaignCentralApiError, Campaign]] = campaigns.map { campaign =>

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ lazy val dependencies = Seq(
   "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor"  % "2.8.9" % Runtime,
   "com.amazonaws"                    % "aws-java-sdk"             % "1.11.213",
   "com.gu"                           %% "play-googleauth"         % "0.7.0",
-  "com.gu"                           %% "content-api-client"      % "11.26",
+  "com.gu"                           %% "content-api-client"      % "11.37",
   "com.squareup.okhttp3"             % "okhttp"                   % "3.9.0",
   "commons-io"                       % "commons-io"               % "2.5",
   "net.logstash.logback"             % "logstash-logback-encoder" % "4.11",


### PR DESCRIPTION
This is required so that I can make use of the new `sponsorship-type` filter I have added to the `Tags` endpoint.