### PR TITLE
Add production office to campaign.

### DIFF
--- a/app/model/Campaign.scala
+++ b/app/model/Campaign.scala
@@ -19,7 +19,8 @@ case class Campaign(
   actualValue: Option[Long] = None,
   startDate: Option[DateTime] = None,
   endDate: DateTime,
-  targets: Map[String, Long] = Map.empty
+  targets: Map[String, Long] = Map.empty,
+  productionOffice: Option[String]
 )
 
 object Campaign {

--- a/app/repositories/contentapi/ContentApi.scala
+++ b/app/repositories/contentapi/ContentApi.scala
@@ -42,7 +42,7 @@ object ContentApi {
       new SearchQuery()
         .section(pathPrefix)
         .showAtoms("all")
-        .showFields("internalComposerCode,isLive,firstPublicationDate,headline")
+        .showFields("internalComposerCode,isLive,firstPublicationDate,headline,productionOffice")
         .showTags("all")
         .pageSize(10)
         .page(page)

--- a/app/services/CampaignTransformer.scala
+++ b/app/services/CampaignTransformer.scala
@@ -37,7 +37,8 @@ object CampaignTransformer {
         campaignLogo = logo,
         startDate = startDate,
         endDate = endDate,
-        targets = Map.empty
+        targets = Map.empty,
+        productionOffice = None
       )
     }
   }


### PR DESCRIPTION
This enables us to filter campaigns by their production office. This has been requested by each of the labs departments in the UK, US and AU as they care about their territory, not a global view.