### PR TITLE
Media events tables cloudformation

### DIFF
--- a/cloudformation/README.md
+++ b/cloudformation/README.md
@@ -1,6 +1,17 @@
  Cloudformation templates
  ========================
  
+ ### campaign-central dynamo Db
+ 
+ ```
+ aws cloudformation update-stack \
+    --stack-name CampaignCentralDynamo-DEV \
+    --template-body file:///$PWD/dynamoDb.yaml \
+    --parameters  ParameterKey=Stage,ParameterValue=DEV \
+    --profile composer \
+    --region eu-west-1
+```
+ 
  ### campaign-central-backups
  
  This template is an AWS Data Pipeline which schedules a weekly job that drops the contents of an old dev-environment

--- a/cloudformation/dynamoDb.yaml
+++ b/cloudformation/dynamoDb.yaml
@@ -29,6 +29,7 @@ Resources:
         - - campaign-central
           - Ref: Stage
           - campaigns
+    DeletionPolicy: Retain
 
   CampaignNotesDBTable:
     Type: AWS::DynamoDB::Table
@@ -52,6 +53,7 @@ Resources:
         - - campaign-central
           - Ref: Stage
           - campaign-notes
+    DeletionPolicy: Retain
 
   CampaignContentDBTable:
     Type: AWS::DynamoDB::Table
@@ -75,6 +77,7 @@ Resources:
         - - campaign-central
           - Ref: Stage
           - campaign-content
+    DeletionPolicy: Retain
 
   ClientDBTable:
     Type: AWS::DynamoDB::Table
@@ -94,6 +97,7 @@ Resources:
         - - campaign-central
           - Ref: Stage
           - clients
+    DeletionPolicy: Retain
 
   CampaignAnalyticsDBTable:
     Type: AWS::DynamoDB::Table
@@ -117,6 +121,7 @@ Resources:
         - - campaign-central
           - Ref: Stage
           - analytics
+    DeletionPolicy: Retain
 
   CampaignUniquesDBTable:
     Type: AWS::DynamoDB::Table
@@ -140,6 +145,7 @@ Resources:
         - - campaign-central
           - Ref: Stage
           - campaign-uniques
+    DeletionPolicy: Retain
 
   CampaignPageViewsDBTable:
     Type: AWS::DynamoDB::Table
@@ -163,6 +169,7 @@ Resources:
         - - campaign-central
           - Ref: Stage
           - campaign-page-views
+    DeletionPolicy: Retain
 
   CampaignReferralsDBTable:
     Type: AWS::DynamoDB::Table
@@ -186,6 +193,7 @@ Resources:
         - - campaign-central
           - Ref: Stage
           - referrals
+    DeletionPolicy: Retain
 
   CampaignReferralsV2DBTable:
     Type: AWS::DynamoDB::Table
@@ -209,6 +217,7 @@ Resources:
         - - campaign-central
           - Ref: Stage
           - referralsv2
+    DeletionPolicy: Retain
 
   CampaignAnalyticsLatestDBTable:
     Type: AWS::DynamoDB::Table
@@ -229,6 +238,7 @@ Resources:
           - Ref: Stage
           - analytics
           - latest
+    DeletionPolicy: Retain
 
   CampaignMediaDBTable:
     Type: AWS::DynamoDB::Table
@@ -249,3 +259,4 @@ Resources:
         - - campaign-central
           - Ref: Stage
           - media
+    DeletionPolicy: Retain

--- a/cloudformation/dynamoDb.yaml
+++ b/cloudformation/dynamoDb.yaml
@@ -29,7 +29,6 @@ Resources:
         - - campaign-central
           - Ref: Stage
           - campaigns
-    DeletionPolicy: Retain
 
   CampaignNotesDBTable:
     Type: AWS::DynamoDB::Table
@@ -53,7 +52,6 @@ Resources:
         - - campaign-central
           - Ref: Stage
           - campaign-notes
-    DeletionPolicy: Retain
 
   CampaignContentDBTable:
     Type: AWS::DynamoDB::Table
@@ -77,7 +75,6 @@ Resources:
         - - campaign-central
           - Ref: Stage
           - campaign-content
-    DeletionPolicy: Retain
 
   ClientDBTable:
     Type: AWS::DynamoDB::Table
@@ -97,7 +94,6 @@ Resources:
         - - campaign-central
           - Ref: Stage
           - clients
-    DeletionPolicy: Retain
 
   CampaignAnalyticsDBTable:
     Type: AWS::DynamoDB::Table
@@ -121,7 +117,6 @@ Resources:
         - - campaign-central
           - Ref: Stage
           - analytics
-    DeletionPolicy: Retain
 
   CampaignUniquesDBTable:
     Type: AWS::DynamoDB::Table
@@ -145,7 +140,6 @@ Resources:
         - - campaign-central
           - Ref: Stage
           - campaign-uniques
-    DeletionPolicy: Retain
 
   CampaignPageViewsDBTable:
     Type: AWS::DynamoDB::Table
@@ -169,7 +163,6 @@ Resources:
         - - campaign-central
           - Ref: Stage
           - campaign-page-views
-    DeletionPolicy: Retain
 
   CampaignReferralsDBTable:
     Type: AWS::DynamoDB::Table
@@ -193,7 +186,6 @@ Resources:
         - - campaign-central
           - Ref: Stage
           - referrals
-    DeletionPolicy: Retain
 
   CampaignReferralsV2DBTable:
     Type: AWS::DynamoDB::Table
@@ -217,7 +209,6 @@ Resources:
         - - campaign-central
           - Ref: Stage
           - referralsv2
-    DeletionPolicy: Retain
 
   CampaignAnalyticsLatestDBTable:
     Type: AWS::DynamoDB::Table
@@ -238,4 +229,23 @@ Resources:
           - Ref: Stage
           - analytics
           - latest
-    DeletionPolicy: Retain
+
+  CampaignMediaDBTable:
+    Type: AWS::DynamoDB::Table
+    DependsOn: CampaignAnalyticsLatestDBTable
+    Properties:
+      AttributeDefinitions:
+      - AttributeName: campaignId
+        AttributeType: S
+      KeySchema:
+      - AttributeName: campaignId
+        KeyType: HASH
+      ProvisionedThroughput:
+        ReadCapacityUnits: '5'
+        WriteCapacityUnits: '5'
+      TableName:
+        Fn::Join:
+        - "-"
+        - - campaign-central
+          - Ref: Stage
+          - media


### PR DESCRIPTION
I'm planning to merge these separately. This template can now be used on DEV and PROD, I've successfully cloudformed both with it. Had to delete a lot of unmanaged DEV tables. It adds the media events table to both stages.