### PR TITLE
Media events component

### DIFF
--- a/app/controllers/CampaignApi.scala
+++ b/app/controllers/CampaignApi.scala
@@ -112,4 +112,13 @@ class CampaignApi(components: ControllerComponents, authAction: AuthAction[AnyCo
       case Right(referrals)              => Ok(Json.toJson(referrals))
     }
   }
+
+  def getCampaignMediaEvents(campaignId: String) = authAction { _ =>
+    CampaignMediaEventsRepository.getCampaignMediaEvents(campaignId) match {
+      case Left(JsonParsingError(error)) => InternalServerError(error)
+      case Left(CampaignNotFound(error)) => NotFound(error)
+      case Left(_)                       => InternalServerError
+      case Right(mediaEvents)            => Ok(Json.toJson(mediaEvents))
+    }
+  }
 }

--- a/app/repositories/CampaignMediaEventsRepository.scala
+++ b/app/repositories/CampaignMediaEventsRepository.scala
@@ -1,0 +1,45 @@
+package repositories
+
+import cats.implicits._
+import com.gu.scanamo._
+import com.gu.scanamo.syntax._
+import model.{CampaignCentralApiError, CampaignNotFound, JsonParsingError}
+import play.api.libs.json.Json
+import services.AWS.DynamoClient
+import services.Config
+import util.DynamoResults.getResultsOrFirstFailure
+
+object CampaignMediaEventsRepository {
+
+  case class PageMedia(
+    mediaId: String,
+    path: String,
+    playEvent: Int,
+    percent25: Int,
+    percent50: Int,
+    percent75: Int,
+    endEvent: Int
+  )
+  case class CampaignMediaEvents(
+    campaignId: String,
+    campaignName: String,
+    pages: Seq[PageMedia]
+  )
+
+  object PageMedia {
+    implicit val PageMediaFormat = Json.format[PageMedia]
+  }
+  object CampaignMediaEvents {
+    implicit val CampaignMediaEventsFormat = Json.format[CampaignMediaEvents]
+  }
+
+  private val table = Table[CampaignMediaEvents](Config().campaignMediaEventsTableName)
+
+  def getCampaignMediaEvents(campaignId: String): Either[CampaignCentralApiError, CampaignMediaEvents] = {
+    getResultsOrFirstFailure(Scanamo.exec(DynamoClient)(table.query('campaignId -> campaignId))) match {
+      case Left(e)          => Left(JsonParsingError(e.show))
+      case Right(Nil)       => Left(CampaignNotFound(s"campaign $campaignId has no media events"))
+      case Right(head :: _) => Right(head)
+    }
+  }
+}

--- a/app/repositories/CampaignMediaEventsRepository.scala
+++ b/app/repositories/CampaignMediaEventsRepository.scala
@@ -14,11 +14,11 @@ object CampaignMediaEventsRepository {
   case class PageMedia(
     mediaId: String,
     path: String,
-    playEvent: Int,
-    percent25: Int,
-    percent50: Int,
-    percent75: Int,
-    endEvent: Int
+    playEvent: Long,
+    percent25: Long,
+    percent50: Long,
+    percent75: Long,
+    endEvent: Long
   )
   case class CampaignMediaEvents(
     campaignId: String,

--- a/app/services/Config.scala
+++ b/app/services/Config.scala
@@ -33,9 +33,10 @@ sealed trait Config {
 
   def logShippingStreamName: Option[String] = None
 
-  def campaignTableName        = s"campaign-central-$stage-campaigns"
-  def campaignNotesTableName   = s"campaign-central-$stage-campaign-notes"
-  def campaignContentTableName = s"campaign-central-$stage-campaign-content"
+  def campaignTableName            = s"campaign-central-$stage-campaigns"
+  def campaignNotesTableName       = s"campaign-central-$stage-campaign-notes"
+  def campaignContentTableName     = s"campaign-central-$stage-campaign-content"
+  def campaignMediaEventsTableName = s"campaign-central-$stage-media"
 
   def clientTableName = s"campaign-central-$stage-clients"
 

--- a/conf/routes
+++ b/conf/routes
@@ -29,7 +29,7 @@ GET /api/v2/campaigns/:id/uniques           controllers.CampaignApi.getCampaignU
 GET /api/campaigns/:id/content              controllers.CampaignApi.getCampaignContent(id: String)
 POST /api/campaigns/:id/refreshFromCAPI     controllers.CampaignApi.refreshCampaignFromCAPI(id: String)
 GET /api/v2/campaigns/:id/referrals         controllers.CampaignApi.getCampaignReferrals(id: String)
-
+GET /api/campaigns/:id/mediaEvents          controllers.CampaignApi.getCampaignMediaEvents(id: String)
 
 #Management Api
 POST   /management/api/refreshExpiringCampaigns         controllers.ManagementApi.refreshCampaigns

--- a/conf/routes
+++ b/conf/routes
@@ -1,12 +1,12 @@
 #Client Side Routes
-GET	/		                          controllers.App.index(id = "")
-GET	/campaigns		                controllers.App.index(id = "")
-GET	/campaigns/:id		            controllers.App.index(id)
-GET	/campaign/:id		              controllers.App.index(id)
-GET	/capiImport		                controllers.App.index(id = "")
-GET	/management/analytics         controllers.App.index(id = "")
-GET	/glossary                     controllers.App.index(id = "")
-GET	/benchmarks                   controllers.App.index(id = "")
+GET /                             controllers.App.index(id = "")
+GET /campaigns                    controllers.App.index(id = "")
+GET /campaigns/:id                controllers.App.index(id)
+GET /campaign/:id                 controllers.App.index(id)
+GET /capiImport                   controllers.App.index(id = "")
+GET /management/analytics         controllers.App.index(id = "")
+GET /glossary                     controllers.App.index(id = "")
+GET /benchmarks                   controllers.App.index(id = "")
 
 
 GET /login            controllers.LogIn.logIn()

--- a/public/actions/CampaignActions/getCampaignMediaEvents.js
+++ b/public/actions/CampaignActions/getCampaignMediaEvents.js
@@ -1,0 +1,37 @@
+import {fetchCampaignMediaEvents} from '../../services/CampaignsApi';
+
+function requestCampaignMediaEvents(id) {
+    return {
+        type:       'CAMPAIGN_MEDIA_EVENTS_GET_REQUEST',
+        id:         id,
+        receivedAt: Date.now()
+    };
+}
+
+function receiveCampaignMediaEvents(campaignMediaEvents) {
+    return {
+        type:        'CAMPAIGN_MEDIA_EVENTS_GET_RECEIVE',
+        campaignMediaEvents:    campaignMediaEvents,
+        receivedAt:  Date.now()
+    };
+}
+
+function errorRecievingCampaignMediaEvents(error) {
+    return {
+        type:       'SHOW_ERROR',
+        message:    'Could not get campaign media events',
+        error:      error,
+        receivedAt: Date.now()
+    };
+}
+
+export function getCampaignMediaEvents(id) {
+    return dispatch => {
+      dispatch(requestCampaignMediaEvents(id));
+      return fetchCampaignMediaEvents(id)
+        .catch(error => dispatch(errorRecievingCampaignMediaEvents(error)))
+        .then(res => {
+          dispatch(receiveCampaignMediaEvents(res));
+        });
+    };
+}

--- a/public/components/Campaign/Campaign.js
+++ b/public/components/Campaign/Campaign.js
@@ -51,18 +51,6 @@ class Campaign extends React.Component {
       return <div>Loading... </div>;
     }
 
-    const totalPageviews = this.props.latestAnalyticsForCampaign.pageviews;
-    const pageviewsPerDevice = this.props.latestAnalyticsForCampaign.pageviewsByDevice;
-    const totalUniques = this.props.latestAnalyticsForCampaign.uniques;
-    const uniquesPerDevice = this.props.latestAnalyticsForCampaign.uniquesByDevice;
-    const uniquesTarget = this.props.campaign.targets && this.props.campaign.targets.uniques;
-
-    const medianAttentionTime = this.props.latestAnalyticsForCampaign.medianAttentionTimeSeconds;
-    const medianPerDevice = this.props.latestAnalyticsForCampaign.medianAttentionTimeByDevice || {};
-
-    const averageDwellTimePerPathSeconds = this.props.latestAnalyticsForCampaign.averageDwellTimePerPathSeconds || {};
-    const weightedAverageDwellTime = this.props.latestAnalyticsForCampaign.weightedAverageDwellTimeForCampaign;
-
     return (
       <div className="campaign">
         <h2>{campaign.name}</h2>

--- a/public/components/Campaign/Campaign.js
+++ b/public/components/Campaign/Campaign.js
@@ -1,4 +1,4 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
 import {Link} from 'react-router';
 import CampaignEdit from '../CampaignInformationEdit/CampaignEdit';
 import CampaignAssets from '../CampaignInformationEdit/CampaignAssets';
@@ -6,6 +6,7 @@ import CampaignAnalytics from '../CampaignAnalytics/CampaignAnalytics';
 import CampaignReferrals from '../CampaignAnalytics/Analytics/CampaignReferrals';
 import CampaignPerformanceOverview from '../CampaignPerformanceOverview/CampaignPerformanceOverview';
 import CampaignPerformanceBreakdown from '../CampaignPerformanceBreakdown/CampaignPerformanceBreakdown';
+import CampaignMediaEvents from '../CampaignMediaEvents/CampaignMediaEvents';
 
 class Campaign extends React.Component {
 
@@ -20,6 +21,7 @@ class Campaign extends React.Component {
       if (this.isAnalysisAvailable(nextProps.campaign)) {
         this.props.campaignAnalyticsActions.getCampaignPageViews(nextProps.campaign.id);
         this.props.campaignAnalyticsActions.getCampaignUniques(nextProps.campaign.id);
+        this.props.analyticsActions.getCampaignMediaEvents(nextProps.campaign.id);
         this.props.analyticsActions.getLatestAnalyticsForCampaign(nextProps.campaign.id);
       }
     }
@@ -79,11 +81,12 @@ class Campaign extends React.Component {
                         latestAnalyticsForCampaign={this.props.latestAnalyticsForCampaign}
                         updateCampaign={this.props.campaignActions.updateCampaign}
                         saveCampaign={this.props.campaignActions.saveCampaign}/>
-        <CampaignAnalytics campaign={campaign} />
+          <CampaignAnalytics campaign={campaign} />
           <CampaignAssets campaign={campaign}
                           getCampaign={this.props.campaignActions.getCampaign}
                           getCampaignContent={this.props.campaignActions.getCampaignContent} />
           <CampaignReferrals campaign={campaign} />
+          <CampaignMediaEvents campaign={campaign} mediaEventsData={this.props.campaignMediaEvents} />
         </div>
       </div>
     );
@@ -102,18 +105,20 @@ import * as getCampaignPageViews from '../../actions/CampaignActions/getCampaign
 import * as getCampaignUniques from '../../actions/CampaignActions/getCampaignUniques';
 import * as clearCampaignAnalytics from '../../actions/CampaignActions/clearCampaignAnalytics';
 import * as getLatestAnalyticsForCampaign from '../../actions/CampaignActions/getLatestAnalyticsForCampaign';
+import * as getCampaignMediaEvents from '../../actions/CampaignActions/getCampaignMediaEvents';
 
 function mapStateToProps(state) {
   return {
     campaign: state.campaign,
-    latestAnalyticsForCampaign: state.latestAnalyticsForCampaign
+    latestAnalyticsForCampaign: state.latestAnalyticsForCampaign,
+    campaignMediaEvents: state.campaignMediaEvents
   };
 }
 
 function mapDispatchToProps(dispatch) {
   return {
     campaignActions: bindActionCreators(Object.assign({}, getCampaign, updateCampaign, saveCampaign, deleteCampaign, getCampaignContent), dispatch),
-    analyticsActions: bindActionCreators(Object.assign({}, getLatestAnalyticsForCampaign), dispatch),
+    analyticsActions: bindActionCreators(Object.assign({}, getLatestAnalyticsForCampaign, getCampaignMediaEvents), dispatch),
     campaignAnalyticsActions: bindActionCreators(Object.assign({}, getCampaignPageViews, getCampaignUniques, clearCampaignAnalytics), dispatch)
   };
 }

--- a/public/components/Campaign/Campaign.js
+++ b/public/components/Campaign/Campaign.js
@@ -12,15 +12,14 @@ class Campaign extends React.Component {
 
   componentWillMount() {
     this.props.campaignActions.getCampaign(this.props.params.id);
-    this.props.analyticsActions.getLatestAnalyticsForCampaign(this.props.params.id);
   }
 
   componentWillReceiveProps(nextProps) {
     if (nextProps.campaign && (!this.props.campaign || nextProps.campaign.id !== this.props.campaign.id)) {
-      this.props.campaignAnalyticsActions.clearCampaignAnalytics();
+      this.props.analyticsActions.clearCampaignAnalytics();
       if (this.isAnalysisAvailable(nextProps.campaign)) {
-        this.props.campaignAnalyticsActions.getCampaignPageViews(nextProps.campaign.id);
-        this.props.campaignAnalyticsActions.getCampaignUniques(nextProps.campaign.id);
+        this.props.analyticsActions.getCampaignPageViews(nextProps.campaign.id);
+        this.props.analyticsActions.getCampaignUniques(nextProps.campaign.id);
         this.props.analyticsActions.getCampaignMediaEvents(nextProps.campaign.id);
         this.props.analyticsActions.getLatestAnalyticsForCampaign(nextProps.campaign.id);
       }
@@ -104,9 +103,10 @@ function mapStateToProps(state) {
 
 function mapDispatchToProps(dispatch) {
   return {
-    campaignActions: bindActionCreators(Object.assign({}, getCampaign, updateCampaign, saveCampaign, deleteCampaign, getCampaignContent), dispatch),
-    analyticsActions: bindActionCreators(Object.assign({}, getLatestAnalyticsForCampaign, getCampaignMediaEvents), dispatch),
-    campaignAnalyticsActions: bindActionCreators(Object.assign({}, getCampaignPageViews, getCampaignUniques, clearCampaignAnalytics), dispatch)
+    campaignActions: bindActionCreators(Object.assign({},
+      getCampaign, updateCampaign, saveCampaign, deleteCampaign, getCampaignContent), dispatch),
+    analyticsActions: bindActionCreators(Object.assign({},
+      getLatestAnalyticsForCampaign, getCampaignMediaEvents, getCampaignPageViews, getCampaignUniques, clearCampaignAnalytics), dispatch)
   };
 }
 

--- a/public/components/Campaign/Campaign.js
+++ b/public/components/Campaign/Campaign.js
@@ -66,7 +66,6 @@ class Campaign extends React.Component {
                         latestAnalyticsForCampaign={this.props.latestAnalyticsForCampaign} />
 
           <CampaignEdit campaign={campaign}
-                        latestAnalyticsForCampaign={this.props.latestAnalyticsForCampaign}
                         updateCampaign={this.props.campaignActions.updateCampaign}
                         saveCampaign={this.props.campaignActions.saveCampaign}/>
           <CampaignAnalytics campaign={campaign} />

--- a/public/components/CampaignInformationEdit/CampaignEdit.js
+++ b/public/components/CampaignInformationEdit/CampaignEdit.js
@@ -44,7 +44,6 @@ class CampaignEdit extends React.Component {
           <div className="campaign__column">
             <CampaignInformationEdit
               campaign={this.props.campaign}
-              latestAnalyticsForCampaign={this.props.latestAnalyticsForCampaign}
               updateCampaign={this.triggerUpdate} />
           </div>
           <div className="campaign__column">

--- a/public/components/CampaignMediaEvents/CampaignMediaEvents.js
+++ b/public/components/CampaignMediaEvents/CampaignMediaEvents.js
@@ -1,0 +1,18 @@
+import React from 'react';
+
+export default class CampaignMediaEvents extends React.Component {
+
+  constructor(props) {
+    super(props);
+  }
+
+  render () {
+    return(
+      <div className="campaign__row">
+        <div className="campaign-box__header">Campaign media events</div>
+          <div>{this.props.mediaEventsData.campaignName}</div>
+      </div>
+    );
+
+  }
+}

--- a/public/components/CampaignMediaEvents/CampaignMediaEvents.js
+++ b/public/components/CampaignMediaEvents/CampaignMediaEvents.js
@@ -7,12 +7,56 @@ export default class CampaignMediaEvents extends React.Component {
   }
 
   render () {
-    return(
+    if (!this.props.mediaEventsData) {
+        return null;
+    }
+    return (
       <div className="campaign__row">
         <div className="campaign-box__header">Campaign media events</div>
-          <div>{this.props.mediaEventsData.campaignName}</div>
+        <div className="campaign-box__body">
+          <div className="campaign-assets__field__value">
+              <table className="campaign-media__table pure-table">
+                <thead>
+                  <tr>
+                    <th className="campaign-media__table--primary-header">Path</th>
+                    <th className="campaign-media__table--header">Play</th>
+                    <th className="campaign-media__table--header">25%</th>
+                    <th className="campaign-media__table--header">50%</th>
+                    <th className="campaign-media__table--header">75%</th>
+                    <th className="campaign-media__table--header">End</th>
+                  </tr>
+                </thead>
+
+                <tbody>
+                {this.props.mediaEventsData.pages.map((
+                    {   endEvent,
+                        path,
+                        percent25,
+                        percent50,
+                        percent75,
+                        playEvent
+                    }) => {
+
+                  const index = path.lastIndexOf("/");
+                  const lastSlug = path.substr(index + 1);
+
+                  return(
+                    <tr key={lastSlug}>
+                      <td>{lastSlug}</td>
+                      <td>{`${playEvent.toLocaleString()}`}</td>
+                      <td>{`${percent25.toLocaleString()}`}</td>
+                      <td>{`${percent50.toLocaleString()}`}</td>
+                      <td>{`${percent75.toLocaleString()}`}</td>
+                      <td>{`${endEvent.toLocaleString()}`}</td>
+                    </tr>
+                  );
+
+                })}
+                </tbody>
+              </table>
+          </div>
+        </div>
       </div>
     );
-
   }
 }

--- a/public/reducers/campaignMediaEventsReducer.js
+++ b/public/reducers/campaignMediaEventsReducer.js
@@ -1,0 +1,11 @@
+
+export default function campaignMediaEventsReducer(state = false, action) {
+  switch (action.type) {
+
+    case 'CAMPAIGN_MEDIA_EVENTS_GET_RECEIVE':
+      return action.campaignMediaEvents || false;
+
+    default:
+      return state;
+  }
+}

--- a/public/reducers/rootReducer.js
+++ b/public/reducers/rootReducer.js
@@ -13,6 +13,7 @@ import campaignSort from './campaignSortReducer';
 import latestAnalytics from './latestAnalyticsReducer';
 import latestAnalyticsForCampaign from './latestAnalyticsForCampaignReducer';
 import benchmarks from './allCampaignBenchmarksReducer';
+import campaignMediaEvents from './campaignMediaEventsReducer';
 
 export default combineReducers({
   error,
@@ -28,5 +29,6 @@ export default combineReducers({
   campaignSort,
   latestAnalytics,
   latestAnalyticsForCampaign,
-  benchmarks
+  benchmarks,
+  campaignMediaEvents
 });

--- a/public/services/CampaignsApi.js
+++ b/public/services/CampaignsApi.js
@@ -93,3 +93,10 @@ export function getCampaignBenchmarks() {
     method: 'get'
   });
 }
+
+export function fetchCampaignMediaEvents(id) {
+  return AuthedReqwest({
+    url: '/api/campaigns/' + id + '/mediaEvents',
+    method: 'get'
+  });
+}

--- a/public/styles/components/campaign/_campaign-media.scss
+++ b/public/styles/components/campaign/_campaign-media.scss
@@ -1,0 +1,14 @@
+
+.campaign-media__table {
+    width: 100%;
+}
+
+.campaign-media__table--header {
+    background-color: $c-grey-200;
+    width: 10%;
+}
+
+.campaign-media__table--primary-header {
+    background-color: $c-grey-200;
+    width: 50%;
+}

--- a/public/styles/main.scss
+++ b/public/styles/main.scss
@@ -16,12 +16,13 @@
 @import './components/campaign-assets/campaign-assets';
 @import './components/campaign-assets/campaign-content-list';
 @import './components/campaign-assets/campaign-cta-list';
-@import './components/campaign/campaign-referrals';
 @import './components/campaign-info/campaign-info';
 @import './components/campaign-info/analytics/analytics';
 @import './components/error-bar/error-bar';
 @import './components/editable-text/editable-text';
 @import './components/campaign/campaign';
+@import './components/campaign/campaign-referrals';
+@import './components/campaign/campaign-media';
 @import './components/campaign-notes/campaign-notes';
 @import './components/tag-select/tag-select';
 @import './components/progress-spinner/progress-spinner';


### PR DESCRIPTION
This adds a table to the campaign page for any media events that were obtained from the db.

![screen shot 2017-11-03 at 11 25 17](https://user-images.githubusercontent.com/4549425/32371748-f10f6eda-c089-11e7-8af1-bb34a57749ad.png)

I could tidy up the path names later on. This can go live, but there won't be any data until `commercial_pageview` is live.