### PR TITLE
Add view-through rate column for Media Events tables

### DIFF
--- a/public/components/CampaignMediaEvents/CampaignMediaEvents.js
+++ b/public/components/CampaignMediaEvents/CampaignMediaEvents.js
@@ -18,12 +18,13 @@ export default class CampaignMediaEvents extends React.Component {
               <table className="campaign-media__table pure-table">
                 <thead>
                   <tr>
-                    <th className="campaign-media__table--primary-header">Path</th>
-                    <th className="campaign-media__table--header">Play</th>
-                    <th className="campaign-media__table--header">25%</th>
-                    <th className="campaign-media__table--header">50%</th>
-                    <th className="campaign-media__table--header">75%</th>
-                    <th className="campaign-media__table--header">End</th>
+                    <th className="campaign-media__table--header campaign-media__table--header--primary">Path</th>
+                    <th className="campaign-media__table--header campaign-media__table--header--secondary">Play</th>
+                    <th className="campaign-media__table--header campaign-media__table--header--secondary">25%</th>
+                    <th className="campaign-media__table--header campaign-media__table--header--secondary">50%</th>
+                    <th className="campaign-media__table--header campaign-media__table--header--secondary">75%</th>
+                    <th className="campaign-media__table--header campaign-media__table--header--secondary">End</th>
+                    <th className="campaign-media__table--header campaign-media__table--header--tertiary">View-through rate</th>
                   </tr>
                 </thead>
 
@@ -48,6 +49,7 @@ export default class CampaignMediaEvents extends React.Component {
                       <td>{`${percent50.toLocaleString()}`}</td>
                       <td>{`${percent75.toLocaleString()}`}</td>
                       <td>{`${endEvent.toLocaleString()}`}</td>
+                      <td>{`${(100 * endEvent / playEvent).toFixed(2).toLocaleString()}%`}</td>
                     </tr>
                   );
 

--- a/public/styles/components/campaign/_campaign-media.scss
+++ b/public/styles/components/campaign/_campaign-media.scss
@@ -1,14 +1,23 @@
 
 .campaign-media__table {
     width: 100%;
+
+    .campaign-media__table--header {
+        @extend %fs-data-3;
+        color: $c-grey-650;
+        font-weight: bold;
+        background-color: $c-grey-200;
+    }
 }
 
-.campaign-media__table--header {
-    background-color: $c-grey-200;
+.campaign-media__table--header--primary {
+    width: 35%;
+}
+
+.campaign-media__table--header--secondary {
     width: 10%;
 }
 
-.campaign-media__table--primary-header {
-    background-color: $c-grey-200;
-    width: 50%;
+.campaign-media__table--header--tertiary {
+    width: 15%;
 }


### PR DESCRIPTION
Add a calculated column for media events tables:

![screen shot 2017-11-03 at 14 33 05](https://user-images.githubusercontent.com/4549425/32378966-18d76584-c0a4-11e7-9ad3-9496773c03ec.png)
