### PR TITLE
Present on-platform referrals as a tree structure

### DIFF
--- a/app/model/CampaignReferral.scala
+++ b/app/model/CampaignReferral.scala
@@ -1,35 +1,13 @@
 package model
 
-import java.time.LocalDate
+import play.api.libs.json._
 
-import play.api.libs.json.{JsNumber, Json, Writes}
-
-case class Component(
-  platform: String,
-  path: String,
-  containerIndex: Int,
-  containerName: String,
-  cardIndex: Int,
-  cardName: String
+case class CampaignReferral(
+  sourceDescription: String,
+  stats: ReferralStats,
+  children: Option[Seq[CampaignReferral]]
 )
 
-object Component {
-  implicit val componentWrites: Writes[Component] = Json.writes[Component]
-}
-
-// A referral to any item in a campaign from an on-platform source in a particular period
-case class CampaignReferral(
-  component: Component,
-  clickCount: Int,
-  impressionCount: Int,
-  firstReferral: LocalDate,
-  lastReferral: LocalDate
-) {
-  val ctr: Double = clickCount / impressionCount.toDouble
-}
-
 object CampaignReferral {
-  implicit val referralWrites: Writes[CampaignReferral] = { referral =>
-    Json.writes[CampaignReferral].writes(referral) + ("ctr" -> JsNumber(referral.ctr))
-  }
+  implicit lazy val writes: Writes[CampaignReferral] = Json.writes[CampaignReferral]
 }

--- a/app/model/ReferralStats.scala
+++ b/app/model/ReferralStats.scala
@@ -1,0 +1,22 @@
+package model
+
+import play.api.libs.json.{JsNumber, Json, Writes}
+
+case class ReferralStats(
+  impressionCount: Int,
+  clickCount: Int
+) {
+  val ctr: Double = clickCount / impressionCount.toDouble
+}
+
+object ReferralStats {
+  implicit val writes: Writes[ReferralStats] = { stats =>
+    Json.writes[ReferralStats].writes(stats) + ("ctr" -> JsNumber(stats.ctr))
+  }
+
+  def fromRows(rows: Seq[CampaignReferralRow]): ReferralStats =
+    ReferralStats(
+      impressionCount = rows.map(_.impressionCount).sum.toInt,
+      clickCount = rows.map(_.clickCount).sum.toInt
+    )
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "ramda": "^0.22.1",
     "react": "^15.3.0",
     "react-dom": "^15.3.0",
+    "react-infinity-menu": "^3.2.0",
     "react-number-format": "^2.0.0",
     "react-redux": "^4.4.5",
     "react-router": "^3.0.0",

--- a/public/components/CampaignAnalytics/Analytics/CampaignReferral.js
+++ b/public/components/CampaignAnalytics/Analytics/CampaignReferral.js
@@ -1,0 +1,25 @@
+import React from "react";
+import NumberFormat from 'react-number-format';
+import "react-infinity-menu/src/infinity-menu.css";
+
+export default class CampaignReferral extends React.Component {
+
+  render() {
+    const depth = Math.floor(this.props.data.keyPath.split(".").length / 2);
+    return (
+      <li key={this.props.data.keyPath} className="pure-g campaign-referral-list" onClick={this.props.onClick}>
+        <div className={'pure-u-'+depth+'-24'} />
+        <div className={'pure-u-'+(17-depth)+'-24 campaign-referral-list__source'}>{this.props.data.name}</div>
+        <div className="pure-u-3-24 campaign-referral-list__impressions">
+          <NumberFormat value={this.props.data.impressionCount} displayType={'text'} thousandSeparator={true}/>
+        </div>
+        <div className="pure-u-2-24 campaign-referral-list__clicks">
+          <NumberFormat value={this.props.data.clickCount} displayType={'text'} thousandSeparator={true}/>
+        </div>
+        <div className="pure-u-2-24 campaign-referral-list__ctr">
+          <NumberFormat value={this.props.data.ctr * 100} displayType={'text'} decimalPrecision={2}/>
+        </div>
+      </li>
+    );
+  }
+}

--- a/public/styles/components/campaign/_campaign-referrals.scss
+++ b/public/styles/components/campaign/_campaign-referrals.scss
@@ -1,25 +1,32 @@
+.infinity-menu-container {
+  font: inherit;
+}
+
+.infinity-menu-display-tree-container > li {
+  background: #F5F5F5;
+}
+
+.campaign-referral-list {
+  font: inherit;
+}
+
 .campaign-referral-list__item {
   border-bottom: 1px solid $c-grey-300;
 }
 
 .campaign-referral-list__row {
   @extend %table__row;
+  font: inherit;
   border-bottom: none;
 }
 
-.campaign-referral-list__platform,
-.campaign-referral-list__path,
-.campaign-referral-list__container,
-.campaign-referral-list__card,
-.campaign-referral-list__impressions,
-.campaign-referral-list__clicks,
-.campaign-referral-list__ctr,
-.campaign-referral-list__date {
+.campaign-referral-list__source {
   @extend %table__cell;
   white-space: normal;
   position: relative;
   overflow: auto;
   border-bottom: none;
+  font: inherit;
 
   &--header {
     @extend %table__cell;
@@ -29,42 +36,21 @@
   }
 }
 
-.campaign-referral-list__platform,
-.campaign-referral-list__platform--header {
-  width: 10%;
-}
-
-.campaign-referral-list__path,
-.campaign-referral-list__path--header {
-  width: 15%;
-}
-
-.campaign-referral-list__container,
-.campaign-referral-list__container--header {
-  width: 20%;
-}
-
-.campaign-referral-list__card,
-.campaign-referral-list__card--header {
-  width: 20%;
-}
-
 .campaign-referral-list__impressions,
-.campaign-referral-list__impressions--header {
-  width: 10%;
-}
-
 .campaign-referral-list__clicks,
-.campaign-referral-list__clicks--header {
-  width: 7%;
-}
+.campaign-referral-list__ctr {
+  @extend %table__cell;
+  white-space: normal;
+  position: relative;
+  overflow: auto;
+  border-bottom: none;
+  text-align: right;
+  font: inherit;
 
-.campaign-referral-list__ctr,
-.campaign-referral-list__ctr--header {
-  width: 7%;
-}
-
-.campaign-referral-list__date,
-.campaign-referral-list__date--header {
-  width: 7%;
+  &--header {
+    @extend %table__cell;
+    background-color: $c-grey-200;
+    font-weight: bold;
+    white-space: normal;
+  }
 }


### PR DESCRIPTION
Instead of a flat structure, the on-platform referrals table is now arranged as a tree with these levels:
container > card > platform > individual dates.

Eg.
Initial collapsed state:
![image](https://user-images.githubusercontent.com/1722550/32449572-d8780df0-c309-11e7-8f74-37d3efe9786c.png)


Fully-expanded state:
![image](https://user-images.githubusercontent.com/1722550/32449613-f8962fb8-c309-11e7-880e-bc9f685c908b.png)
