### PR TITLE
Log CC users' access as separate field

### DIFF
--- a/app/controllers/App.scala
+++ b/app/controllers/App.scala
@@ -1,16 +1,24 @@
 package controllers
 
 import com.gu.googleauth.AuthAction
+import net.logstash.logback.argument.StructuredArguments.value
 import play.api.Logger
 import play.api.libs.json.Json
 import play.api.mvc._
 import services.Config
+import services.LogShipping.logMessageAndCustomField
 
 class App(components: ControllerComponents, authAction: AuthAction[AnyContent])
   extends AbstractController(components) {
 
+  private lazy val logger = Logger(this.getClass)
+
   def index(id: String = "") = authAction { implicit request =>
-    Logger.info(s"${request.user.email} accessed Campaign Central.")
+    logMessageAndCustomField(
+      logger,
+      message = "{} accessed Campaign Central.",
+      field = value("accessedBy", request.user.email)
+    )
 
     val jsFileName = "build/app.js"
 

--- a/app/services/LogShipping.scala
+++ b/app/services/LogShipping.scala
@@ -3,6 +3,7 @@ package services
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.classic.{Logger => LogbackLogger}
 import com.gu.logback.appender.kinesis.KinesisAppender
+import net.logstash.logback.argument.StructuredArgument
 import net.logstash.logback.layout.LogstashLayout
 import org.slf4j.{LoggerFactory, Logger => SLFLogger}
 import play.api.Logger
@@ -38,4 +39,8 @@ object LogShipping extends AwsInstanceTags {
       rootLogger.info("Configured kinesis appender")
     }
   }
+
+  // see https://github.com/logstash/logstash-logback-encoder#loggingevent-fields
+  def logMessageAndCustomField(logger: Logger, message: String, field: StructuredArgument): Unit =
+    logger.underlyingLogger.info(message, field)
 }


### PR DESCRIPTION
The message field in Kibana is analysed, so it's easier to chart unique access to Campaign Central if we hold access in another field as well.