### PR TITLE
Set root of referrals tree to show global summary for campaign

### DIFF
--- a/app/model/CampaignReferral.scala
+++ b/app/model/CampaignReferral.scala
@@ -10,4 +10,71 @@ case class CampaignReferral(
 
 object CampaignReferral {
   implicit lazy val writes: Writes[CampaignReferral] = Json.writes[CampaignReferral]
+
+  def fromRows(rows: Seq[CampaignReferralRow]): Seq[CampaignReferral] = {
+
+    def childReferrals[A](rows: Seq[CampaignReferralRow])(group: CampaignReferralRow => A)(description: A => String)(
+      children: Seq[CampaignReferralRow] => Option[Seq[CampaignReferral]]): List[CampaignReferral] =
+      rows
+        .groupBy(group)
+        .flatMap {
+          case (a, subRows) =>
+            Some(
+              CampaignReferral(
+                sourceDescription = description(a),
+                stats = ReferralStats.fromRows(subRows),
+                children = children(subRows)
+              ))
+        }
+        .toList
+        .sortBy(ref => (-ref.stats.ctr, ref.sourceDescription))
+
+    def formatPlatform(platform: String): String = platform match {
+      case "NEXT_GEN"           => "Web"
+      case "ANDROID_NATIVE_APP" => "Android"
+      case "IOS_NATIVE_APP"     => "iOS"
+      case "WINDOWS_NATIVE_APP" => "Windows"
+      case other                => other
+    }
+
+    val filtered = rows
+      .filter { row =>
+        row.path.nonEmpty && row.impressionCount > 0
+      }
+
+    def referralsByPath(pathRows: Seq[CampaignReferralRow]): Seq[CampaignReferral] =
+      childReferrals(pathRows)(_.formattedPath)(identity) { containerRows =>
+        Some(referralsByContainer(containerRows))
+      }
+
+    def referralsByContainer(containerRows: Seq[CampaignReferralRow]): Seq[CampaignReferral] =
+      childReferrals(containerRows)(_.containerName) {
+        case Some(containerName) => s"Container: $containerName"
+        case None                => ""
+      } { cardRows =>
+        Some(referralsByCard(cardRows))
+      }
+
+    def referralsByCard(cardRows: Seq[CampaignReferralRow]): Seq[CampaignReferral] =
+      childReferrals(cardRows) { row =>
+        (row.cardIndex, row.cardName)
+      } {
+        case (Some(cardIndex), Some(cardName)) => s"Card #$cardIndex: $cardName"
+        case _                                 => ""
+      } { platformRows =>
+        Some(referralsByPlatform(platformRows))
+      }
+
+    def referralsByPlatform(platformRows: Seq[CampaignReferralRow]): Seq[CampaignReferral] =
+      childReferrals(platformRows)(_.platform)(formatPlatform)(dateRows => Some(referralsByDate(dateRows)))
+
+    def referralsByDate(dateRows: Seq[CampaignReferralRow]): Seq[CampaignReferral] =
+      childReferrals(dateRows)(_.referralDate)(identity)(_ => None)
+
+    val treeRoot = childReferrals(filtered)(_ => 1)(_ => "All fronts") { pathRows =>
+      Some(referralsByPath(pathRows))
+    }
+
+    treeRoot
+  }
 }

--- a/app/repositories/CampaignReferralRepository.scala
+++ b/app/repositories/CampaignReferralRepository.scala
@@ -12,63 +12,10 @@ object CampaignReferralRepository {
 
   private val table = Table[CampaignReferralRow](Config().campaignReferralTableName)
 
-  def getCampaignReferrals(campaignId: String): Either[CampaignCentralApiError, List[CampaignReferral]] = {
-
-    def subReferrals[A](rows: Seq[CampaignReferralRow])(group: CampaignReferralRow => A)(description: A => String)(
-      children: Seq[CampaignReferralRow] => Option[Seq[CampaignReferral]]): List[CampaignReferral] =
-      rows
-        .groupBy(group)
-        .flatMap {
-          case (a, subRows) =>
-            Some(
-              CampaignReferral(
-                sourceDescription = description(a),
-                stats = ReferralStats.fromRows(subRows),
-                children = children(subRows)
-              ))
-        }
-        .toList
-        .sortBy(ref => (-ref.stats.ctr, ref.sourceDescription))
-
+  def getCampaignReferrals(campaignId: String): Either[CampaignCentralApiError, Seq[CampaignReferral]] = {
     getResultsOrFirstFailure(Scanamo.exec(DynamoClient)(table.query('campaignId -> campaignId))) match {
-
-      case Left(e) => Left(JsonParsingError(e.show))
-
-      case Right(rows) =>
-        val filtered = rows
-          .filter { row =>
-            row.path.nonEmpty && row.impressionCount > 0
-          }
-
-        val referrals = subReferrals(filtered)(_.formattedPath)(identity) { pathRows =>
-          Some(subReferrals(pathRows)(_.containerName) {
-            case Some(containerName) => s"Container: $containerName"
-            case None                => ""
-          } { containerRows =>
-            Some(subReferrals(containerRows) { row =>
-              (row.cardIndex, row.cardName)
-            } {
-              case (Some(cardIndex), Some(cardName)) => s"Card #$cardIndex: $cardName"
-              case _                                 => ""
-            } { cardRows =>
-              Some(subReferrals(cardRows)(_.platform)(formatPlatform) { platformRows =>
-                Some(subReferrals(platformRows)(_.referralDate)(identity) { _ =>
-                  None
-                })
-              })
-            })
-          })
-        }
-
-        Right(referrals)
+      case Left(e)     => Left(JsonParsingError(e.show))
+      case Right(rows) => Right(CampaignReferral.fromRows(rows))
     }
-  }
-
-  private def formatPlatform(platform: String): String = platform match {
-    case "NEXT_GEN"           => "Web"
-    case "ANDROID_NATIVE_APP" => "Android"
-    case "IOS_NATIVE_APP"     => "iOS"
-    case "WINDOWS_NATIVE_APP" => "Windows"
-    case other                => other
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ lazy val dependencies = Seq(
   "org.slf4j"                        % "slf4j-api"                % slf4jVersion,
   "org.slf4j"                        % "jcl-over-slf4j"           % slf4jVersion,
   "com.gu"                           %% "scanamo"                 % "0.9.5",
-  "org.scalatest"                    %% "scalatest"               % "3.0.4" % Test
+  "org.scalacheck"                   %% "scalacheck"              % "1.13.5" % Test
 )
 
 lazy val root = (project in file("."))

--- a/public/components/CampaignAnalytics/Analytics/CampaignReferrals.js
+++ b/public/components/CampaignAnalytics/Analytics/CampaignReferrals.js
@@ -66,6 +66,16 @@ class CampaignReferrals extends React.Component {
 
   render() {
 
+    if (this.state && this.state.tree && this.state.tree.length === 0) {
+      return (
+        <div className="campaign-info campaign-box">
+          <div className="campaign-box__header">Referrals from on-platform</div>
+          <div className="campaign-box__body">There are currently no on-platform referrals recorded for this campaign.
+          </div>
+        </div>
+      )
+    }
+
     if (this.state && this.state.tree) {
       return (
         <div className="campaign-info campaign-box">

--- a/public/styles/components/campaign/_campaign-referrals.scss
+++ b/public/styles/components/campaign/_campaign-referrals.scss
@@ -1,4 +1,5 @@
 .infinity-menu-container {
+  border: 1px solid #dcdcdc;
   font: inherit;
 }
 
@@ -6,7 +7,7 @@
   cursor: pointer;
 }
 
-.infinity-menu-display-tree-container > li {
+.infinity-menu-display-tree-container li:hover {
   background: #F5F5F5;
 }
 

--- a/test/model/CampaignReferralFromRowsSpec.scala
+++ b/test/model/CampaignReferralFromRowsSpec.scala
@@ -52,12 +52,12 @@ object CampaignReferralFromRowsSpec extends Properties("CampaignReferral.fromRow
 
   property("Stats at any arbitrary level sum to stats of parent") = forAll { rows: Seq[CampaignReferralRow] =>
     val statsMatch = for {
-      gp       <- CampaignReferral.fromRows(rows).headOption
-      p        <- gp.children.flatMap(_.headOption)
-      children <- p.children
+      grandparent <- CampaignReferral.fromRows(rows).headOption
+      parent      <- grandparent.children.flatMap(_.headOption)
+      children    <- parent.children
     } yield {
       val childrenStats = children.map(_.stats)
-      p.stats == ReferralStats(
+      parent.stats == ReferralStats(
         impressionCount = childrenStats.map(_.impressionCount).sum,
         clickCount = childrenStats.map(_.clickCount).sum
       )

--- a/test/model/CampaignReferralFromRowsSpec.scala
+++ b/test/model/CampaignReferralFromRowsSpec.scala
@@ -1,0 +1,67 @@
+package model
+
+import org.scalacheck.Prop.{BooleanOperators, forAll}
+import org.scalacheck._
+
+object CampaignReferralFromRowsSpec extends Properties("CampaignReferral.fromRows") {
+
+  private implicit lazy val arbRow: Arbitrary[CampaignReferralRow] = Arbitrary(
+    for {
+      referralDate    <- Gen.alphaNumStr
+      platform        <- Gen.alphaStr
+      path            <- Gen.option(Gen.alphaStr)
+      containerIndex  <- Gen.option(Gen.choose(1, 50))
+      containerName   <- Gen.option(Gen.alphaStr)
+      cardIndex       <- Gen.option(Gen.choose(1, 50))
+      cardName        <- Gen.option(Gen.alphaStr)
+      clickCount      <- Gen.choose[Long](0, 1000000000)
+      impressionCount <- Gen.choose[Long](0, 1000000000)
+    } yield {
+      CampaignReferralRow(
+        campaignId = "campaignId",
+        hash = "hash",
+        referralDate = referralDate,
+        platform = platform,
+        edition = Some("edition"),
+        path = path,
+        containerIndex = containerIndex,
+        containerName = containerName,
+        cardIndex = cardIndex,
+        cardName = cardName,
+        clickCount = clickCount,
+        impressionCount = impressionCount,
+        unparsedComponent = Some("unparsedComponent")
+      )
+    }
+  )
+
+  property("Tree root is singular") = forAll { rows: Seq[CampaignReferralRow] =>
+    rows.forall(_.path.isEmpty) ==> CampaignReferral.fromRows(rows).isEmpty
+    rows.exists(_.path.nonEmpty) ==> { CampaignReferral.fromRows(rows).size == 1 }
+  }
+
+  property("Tree root contains stats from all rows with non-empty paths") = forAll { rows: Seq[CampaignReferralRow] =>
+    rows.exists(_.path.nonEmpty) ==> {
+      val rowsWithPaths = rows.filter(_.path.nonEmpty)
+      CampaignReferral.fromRows(rowsWithPaths).head.stats == ReferralStats(
+        impressionCount = rowsWithPaths.map(_.impressionCount).sum.toInt,
+        clickCount = rowsWithPaths.map(_.clickCount).sum.toInt
+      )
+    }
+  }
+
+  property("Stats at any arbitrary level sum to stats of parent") = forAll { rows: Seq[CampaignReferralRow] =>
+    val statsMatch = for {
+      gp       <- CampaignReferral.fromRows(rows).headOption
+      p        <- gp.children.flatMap(_.headOption)
+      children <- p.children
+    } yield {
+      val childrenStats = children.map(_.stats)
+      p.stats == ReferralStats(
+        impressionCount = childrenStats.map(_.impressionCount).sum,
+        clickCount = childrenStats.map(_.clickCount).sum
+      )
+    }
+    statsMatch.forall(result => result)
+  }
+}


### PR DESCRIPTION
Root now says 'All fronts' and gives a single impressions, clicks and CTR value for the whole campaign.

There's a refactor and some of the code has moved around a bit as well.
