### PR TITLE
Reinstate coursier

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -18,6 +18,7 @@ dependencies:
   cache_directories:
     - "~/.ivy2/cache"
     - "~/.sbt"
+    - "~/.coursier"
     - "target/resolution-cache"
     - "target/streams"
     - "project/target/resolution-cache"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,6 +12,8 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.2")
 
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.3")
 
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC13")
+
 addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.12")
 
 libraryDependencies += "org.vafer" % "jdeb" % "1.3" artifacts (Artifact("jdeb", "jar", "jar"))


### PR DESCRIPTION
I took it out when I upgraded to SBT 1.0 (#192) but there was no need.