### PR TITLE
Use GA for tracking

### DIFF
--- a/app/controllers/App.scala
+++ b/app/controllers/App.scala
@@ -26,10 +26,12 @@ class App(components: ControllerComponents, authAction: AuthAction[AnyContent]) 
     }
 
     val clientConf = Map(
-      "tagManagerUrl" -> Config().tagManagerApiUrl,
-      "composerUrl"   -> Config().composerUrl,
-      "liveUrl"       -> Config().liveUrl,
-      "previewUrl"    -> Config().previewUrl
+      "stage"          -> Config().stage,
+      "tagManagerUrl"  -> Config().tagManagerApiUrl,
+      "composerUrl"    -> Config().composerUrl,
+      "liveUrl"        -> Config().liveUrl,
+      "previewUrl"     -> Config().previewUrl,
+      "gaTrackingCode" -> Config().gaTrackingCode
     )
 
     Ok(views.html.Application.app("Campaign Central", jsLocation, Json.toJson(clientConf).toString))

--- a/app/services/Config.scala
+++ b/app/services/Config.scala
@@ -52,6 +52,8 @@ sealed trait Config {
   def liveUrl: String
   def previewUrl: String
 
+  def gaTrackingCode: String
+
   // remote configuration is used for things we don't want to check in to version control
   // such as passwords, private urls, and gossip about other teams
 
@@ -110,6 +112,8 @@ class DevConfig extends Config {
   override def composerUrl           = "https://composer.local.dev-gutools.co.uk"
   override def liveUrl               = "https://www.theguardian.com"
   override def previewUrl            = "https://viewer.gutools.co.uk/preview"
+
+  override def gaTrackingCode: String = "dummy"
 }
 
 class ProdConfig extends Config {
@@ -120,4 +124,6 @@ class ProdConfig extends Config {
   override def composerUrl           = "https://composer.gutools.co.uk"
   override def liveUrl               = "https://www.theguardian.com"
   override def previewUrl            = "https://viewer.gutools.co.uk/preview"
+
+  override def gaTrackingCode: String = "UA-78705427-12"
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "ramda": "^0.22.1",
     "react": "^15.3.0",
     "react-dom": "^15.3.0",
+    "react-ga": "^2.3.5",
     "react-infinity-menu": "^3.2.0",
     "react-number-format": "^2.0.0",
     "react-redux": "^4.4.5",

--- a/public/app.js
+++ b/public/app.js
@@ -1,10 +1,12 @@
 import React from 'react';
-import { render } from 'react-dom';
-import { Provider } from 'react-redux';
+import {render} from 'react-dom';
+import {Provider} from 'react-redux';
 
 import configureStore from './util/configureStore';
 import {setStore} from './util/storeAccessor';
 import {router} from './router';
+import ReactGA from 'react-ga';
+import {browserHistory} from 'react-router';
 
 import './styles/main.scss';
 
@@ -35,4 +37,24 @@ render(
     <Provider store={store}>
       {router}
     </Provider>
-, document.getElementById('react-mount'));
+, document.getElementById('react-mount')
+);
+
+
+const devEnv = config.stage === 'DEV';
+
+const trackPageView = location => {
+  ReactGA.pageview(location.pathname + location.search);
+};
+
+const initGa = history => {
+  ReactGA.initialize(config.gaTrackingCode);
+  if (devEnv) {
+    // see https://developers.google.com/analytics/devguides/collection/analyticsjs/debugging#testing_your_implementation_without_sending_hits
+    ReactGA.ga('set', 'sendHitTask', null);
+  }
+  history.listen(trackPageView);
+  trackPageView(window.location);
+};
+
+initGa(browserHistory);


### PR DESCRIPTION
This sends a pageview-tracking beacon to GA on URLs controlled by Play and controlled by React.