### PR TITLE
Set write throughput ratio to 1.0 in dev table copy job

### DIFF
--- a/cloudformation/campaign-central-backups.yaml
+++ b/cloudformation/campaign-central-backups.yaml
@@ -30,6 +30,18 @@ Resources:
               Key: "default"
               StringValue: "0.2"
         -
+          Id: "myDDBWriteThroughputRatio"
+          Attributes:
+            -
+              Key: "description"
+              StringValue: "DynamoDB write throughput ratio"
+            -
+              Key: "type"
+              StringValue: "Double"
+            -
+              Key: "default"
+              StringValue: "1.0"
+        -
           Id: "mySourceTableName"
           Attributes:
             -
@@ -89,6 +101,9 @@ Resources:
             -
               Key: "readThroughputPercent"
               StringValue: "#{myDDBReadThroughputRatio}"
+            -
+              Key: "writeThroughputPercent"
+              StringValue: "#{myDDBWriteThroughputRatio}"
 
         -
           Id: "DDBExportFormat"
@@ -157,7 +172,7 @@ Resources:
           Fields:
             -
               Key: "terminateAfter"
-              StringValue: "2 Hours"
+              StringValue: "5 Hours"
             -
               Key: "amiVersion"
               StringValue: "3.3.2"


### PR DESCRIPTION
No other process is writing to dev tables so should be safe.

It seems to take a lot longer than 2 hours to write some of the tables, but the data pipeline job doesn't show an error.  This is why a lot of the campaign data is missing in dev.

By looking at the write metrics for each table we should be able to see how long it actually takes, and change the timeout accordingly.
