### PR TITLE
Permit query operation in Dynamo.

### DIFF
--- a/cloudformation/campaign-central.yaml
+++ b/cloudformation/campaign-central.yaml
@@ -194,6 +194,7 @@ Resources:
           - dynamodb:UpdateItem
           - dynamodb:BatchWriteItem
           - dynamodb:Scan
+          - dynamodb:query
           Resource:
           - !Sub arn:aws:dynamodb:*:${AWS::AccountId}:table/campaign-central-${Stage}-campaign-page-views
           - !Sub arn:aws:dynamodb:*:${AWS::AccountId}:table/campaign-central-${Stage}-campaign-uniques


### PR DESCRIPTION
This was preventing the media events job to run within the data lake. @rich-nguyen FYI.