### PR TITLE
Fix social referral bug

### DIFF
--- a/app/model/SocialReferralRow.scala
+++ b/app/model/SocialReferralRow.scala
@@ -5,7 +5,7 @@ case class SocialReferralRow(
   hash: String,
   referralDate: String,
   referringDomain: String,
-  territory: String,
+  territory: Option[String],
   paid: Boolean,
   clickCount: Long,
 )

--- a/test/model/SocialReferralFromRowsSpec.scala
+++ b/test/model/SocialReferralFromRowsSpec.scala
@@ -17,7 +17,7 @@ object SocialReferralFromRowsSpec extends Properties("SocialReferral.fromRows") 
         hash = "hash",
         referralDate = referralDate,
         referringDomain = referringDomain,
-        territory = "territory",
+        territory = None,
         paid = paid,
         clickCount = clickCount
       )


### PR DESCRIPTION
Territory was expected for all social referrals, even though in some cases there's no territory in the data lake.