### PR TITLE
Remove social referrals warning

### DIFF
--- a/public/components/CampaignAnalytics/Analytics/DateRangeEditor.js
+++ b/public/components/CampaignAnalytics/Analytics/DateRangeEditor.js
@@ -33,18 +33,30 @@ class DateRangeEditor extends React.Component {
   }
 
   render() {
+    let dataThreshold = 1504220400000; // 1 Sep 2017
+    let today = Date.now();
+    let startDate = DateRangeEditor.toDate(Math.max(dataThreshold, Date.parse(this.state.startDate)));
+    let endDate = DateRangeEditor.toDate(Math.min(today, Date.parse(this.state.endDate)));
+    let minDate = DateRangeEditor.toDate(Math.max(dataThreshold, this.props.campaign.startDate));
+    let maxDate = DateRangeEditor.toDate(Math.min(today, this.props.campaign.endDate));
     return (
       <div className="campaign-referral-daterange">
         <label>From&nbsp;
-          <input type="date" name="startDate" defaultValue={this.state.startDate} onChange={this.handleChange}
-                 min={DateRangeEditor.toDate(this.props.campaign.startDate)}
-                 max={DateRangeEditor.toDate(this.props.campaign.endDate)}
+          <input type="date"
+                 name="startDate"
+                 defaultValue={startDate}
+                 onChange={this.handleChange}
+                 min={minDate}
+                 max={maxDate}
                  className="campaign-referral-daterange-field"/>
         </label>
         <label>To&nbsp;
-          <input type="date" name="endDate" defaultValue={this.state.endDate} onChange={this.handleChange}
-                 min={DateRangeEditor.toDate(this.props.campaign.startDate)}
-                 max={DateRangeEditor.toDate(this.props.campaign.endDate)}
+          <input type="date"
+                 name="endDate"
+                 defaultValue={endDate}
+                 onChange={this.handleChange}
+                 min={minDate}
+                 max={maxDate}
                  className="campaign-referral-daterange-field"/>
         </label>
       </div>

--- a/public/components/CampaignAnalytics/Analytics/SocialReferrals.js
+++ b/public/components/CampaignAnalytics/Analytics/SocialReferrals.js
@@ -5,7 +5,7 @@ class SocialReferrals extends React.Component {
 
   static renderRow(referral, index) {
     return (
-      <tr key={index}>
+      <tr key={index} className="campaign-referral-list__item">
         <td>{referral.referringPlatform}</td>
         <td className="numeric-value">{referral.organicClickCount.toLocaleString()}</td>
         <td className="numeric-value">{referral.paidClickCount.toLocaleString()}</td>
@@ -47,7 +47,6 @@ class SocialReferrals extends React.Component {
     return (
       <section className="campaign-assets__field__value">
         <h3>Social</h3>
-        <p><i className="i-warning"/>Beware! Only partial data at present.</p>
         {this.renderBody()}
       </section>
     )


### PR DESCRIPTION
Have backfilled data from 1 September now so no need for warning about missing data.

This PR also modifies the date-range picker so that it's only possible to choose dates between 1 September and the current date.  Because that's all the data that's available.