### PR TITLE
Fix links and benchmarks

### DIFF
--- a/public/components/Campaigns/Benchmarks.js
+++ b/public/components/Campaigns/Benchmarks.js
@@ -1,6 +1,7 @@
 import React, {Component, PropTypes} from 'react';
 import BigCardMetric from '../CampaignPerformanceOverview/BigCardMetric';
 import {formatToMinutes} from '../../util/minutesFormatter';
+import isEqual from 'lodash';
 
 
 class BenchmarkSet extends Component {
@@ -50,7 +51,7 @@ class Benchmarks extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (JSON.stringify(nextProps.benchmarks) !== JSON.stringify(this.props.benchmarks) || this.props.territory !== nextProps.territory) {
+    if (!isEqual(nextProps.benchmarks, this.props.benchmarks) || this.props.territory !== nextProps.territory) {
       this.props.benchmarkActions.getBenchmarks(this.props.territory);
     }
   }

--- a/public/components/Campaigns/Benchmarks.js
+++ b/public/components/Campaigns/Benchmarks.js
@@ -50,7 +50,7 @@ class Benchmarks extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.benchmarks !== this.props.benchmarks || this.props.territory !== nextProps.territory) {
+    if (JSON.stringify(nextProps.benchmarks) !== JSON.stringify(this.props.benchmarks) || this.props.territory !== nextProps.territory) {
       this.props.benchmarkActions.getBenchmarks(this.props.territory);
     }
   }

--- a/public/components/Sidebar/Sidebar.js
+++ b/public/components/Sidebar/Sidebar.js
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react';
 import {NavLink} from 'react-router-dom';
 import Moment from 'moment';
+import { withRouter } from 'react-router-dom';
 
 class Sidebar extends React.Component {
 
@@ -152,4 +153,4 @@ function mapDispatchToProps(dispatch) {
   };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(Sidebar);
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(Sidebar));


### PR DESCRIPTION
This brings two fixes;

Once moved over to using `NavList` for the side links, they weren't updating based on what was in the browsers location; this adds `withRouter` on the `connect` of `Sidebar` in order for it to notice location updates.

Also, one of the comparisons in `Benchmarks` was ALWAYS true as the object is deep which would either mean we would have to use a deep comparison; this switched the comparison to use `lodash.isEqual`. (The result of this was swallowing up all of DyanmoDBs provisioned read throughput)

@kelvin-chappell @LATaylor-guardian 