### PR TITLE
Capi preview IAM auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You will then need to create a local configuration file. The easiest way to do t
 cp conf/example-local.conf conf/local.conf
 ```
 
-The campaign-central is a standard play app, so to run it's `sbt run`.  You will need to have developer credentials configured in an AWS composer profile to be able to run it.  To test that the play app is running independently of nginx, try [hitting http://localhost:2267](hitting http://localhost:2267).
+The campaign-central is a standard play app, so to run it's `sbt run`.  You will need to have developer credentials configured in an AWS composer profile to be able to run it, and also CAPI apiGatewayInvoke credentials.  To test that the play app is running independently of nginx, try [hitting http://localhost:2267](hitting http://localhost:2267).
 
 After running this, campaign central
 will be available at [https://campaign-central.local.dev-gutools.co.uk](https://campaign-central.local.dev-gutools.co.uk).

--- a/app/services/Config.scala
+++ b/app/services/Config.scala
@@ -61,10 +61,9 @@ sealed trait Config {
   lazy val googleAnalyticsViewId: String      = getRequiredRemoteStringProperty("googleAnalytivsViewId")
   lazy val googleAnalyticsGlabsViewId: String = getRequiredRemoteStringProperty("googleAnalytivsGlabsViewId")
 
-  lazy val capiKey: String             = getRequiredRemoteStringProperty("capi.key")
-  lazy val capiPreviewUrl: String      = getRequiredRemoteStringProperty("capi.preview.url")
-  lazy val capiPreviewUser: String     = getRequiredRemoteStringProperty("capi.preview.username")
-  lazy val capiPreviewPassword: String = getRequiredRemoteStringProperty("capi.preview.password")
+  lazy val capiKey: String         = getRequiredRemoteStringProperty("capi.key")
+  lazy val capiPreviewUrl: String  = getRequiredRemoteStringProperty("capi.preview.iam-url")
+  lazy val capiPreviewRole: String = getRequiredRemoteStringProperty("capi.preview.role")
 
   def googleServiceAccountJsonInputStream: InputStream = {
     val jsonLocation    = getRequiredRemoteStringProperty("googleServiceAccountCredentialsLocation")

--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,7 @@ lazy val dependencies = Seq(
   "com.amazonaws"                    % "aws-java-sdk"             % "1.11.248",
   "com.gu"                           %% "play-googleauth"         % "0.7.0",
   "com.gu"                           %% "content-api-client"      % "11.45",
+  "com.gu"                           %% "content-api-client-aws"  % "0.5",
   "com.squareup.okhttp3"             % "okhttp"                   % "3.9.1",
   "commons-io"                       % "commons-io"               % "2.6",
   "net.logstash.logback"             % "logstash-logback-encoder" % "4.11",

--- a/cloudformation/campaign-central.yaml
+++ b/cloudformation/campaign-central.yaml
@@ -47,6 +47,10 @@ Parameters:
     Description: 'Account number for the Ophan team to permit them to write to our dynamodb tables.'
     Type: String
 
+  CapiPreviewRole:
+    Type: String
+    Description: ARN of the CAPI preview role
+
 Mappings:
   Config:
     CODE:
@@ -230,6 +234,18 @@ Resources:
       Path: "/"
       Roles:
       - Ref: CampaignCentralRole
+
+  AssumeCapiPreviewRolePolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: AssumeCapiPreviewRole
+      PolicyDocument:
+        Statement:
+        - Effect: Allow
+          Action: sts:AssumeRole
+          Resource: !Ref CapiPreviewRole
+      Roles:
+      - !Ref CampaignCentralRole
 
   SSHSecurityGroup:
     Type: AWS::EC2::SecurityGroup


### PR DESCRIPTION
We are in the process of changing how we authorise access to CAPI preview. In the past we have used basic auth (in Concierge), with the usernames/passwords maintained by the CAPI team.
Instead we will use api-gateway to move authorisation out of concierge and avoid having to maintain usernames/passwords.

The api-gateway uses IAM authorisation. This means the app assumes a cross-account role, and signs each (preview) request using this role.

Note - this means you will now need capi credentials to run the app locally.
I've updated DEV and PROD config files in s3, but left the old preview config items there for now in case we want to roll back.

Tested locally using `curl -XPOST localhost:2267/management/api/refreshExpiringCampaigns`