### PR TITLE
Update campaign-central.yaml

### DIFF
--- a/cloudformation/campaign-central.yaml
+++ b/cloudformation/campaign-central.yaml
@@ -142,24 +142,6 @@ Resources:
       Roles:
       - Ref: CampaignCentralRole
 
-  CampaignCentralGetTeamKeysPolicy:
-    Type: AWS::IAM::Policy
-    Properties:
-      PolicyName: CampaignCentralGetTeamKeysPolicy
-      PolicyDocument:
-        Statement:
-        - Effect: Allow
-          Action:
-          - s3:GetObject
-          Resource:
-          - arn:aws:s3:::github-public-keys/*
-        - Effect: Allow
-          Action:
-          - s3:ListBucket
-          Resource: arn:aws:s3:::github-public-keys
-      Roles:
-      - Ref: CampaignCentralRole
-
   CampaignCentralCloudwatchPolicy:
     Type: AWS::IAM::Policy
     Properties:


### PR DESCRIPTION
The github-keys-to-s3 project is deprecated in favour of SSM. In order to further enforce this, we are deprecating the stack, this means the bucket github-public-keys will no longer be accessible outside of it's parent account.

This change removes the policy to read from the bucket as it is now redundant.

Note:
- This change does not add the SSM policy
- This change does not remove port 22 ingress on security groups